### PR TITLE
Allow Passing RUSTFLAGS Into Cargo Build

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -65,7 +65,7 @@ set(_CORROSION_RUST_CARGO_TARGET ${Rust_CARGO_TARGET} CACHE INTERNAL "target tri
 
 function(_add_cargo_build)
     set(options "")
-    set(one_value_args PACKAGE TARGET MANIFEST_PATH)
+    set(one_value_args PACKAGE TARGET MANIFEST_PATH RUSTFLAGS)
     set(multi_value_args BYPRODUCTS)
     cmake_parse_arguments(
         ACB
@@ -174,6 +174,7 @@ function(_add_cargo_build)
                 CMAKECARGO_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
                 CMAKECARGO_LINK_LIBRARIES=${link_libs}
                 CMAKECARGO_LINK_DIRECTORIES=${search_dirs}
+                RUSTFLAGS=${ACB_RUSTFLAGS}
                 ${link_prefs}
                 ${compilers}
                 ${lang_targets}
@@ -211,7 +212,7 @@ endfunction(_add_cargo_build)
 
 function(corrosion_import_crate)
     set(OPTIONS)
-    set(ONE_VALUE_KEYWORDS MANIFEST_PATH)
+    set(ONE_VALUE_KEYWORDS MANIFEST_PATH RUSTFLAGS)
     set(MULTI_VALUE_KEYWORDS CRATES)
     cmake_parse_arguments(COR "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}" ${ARGN})
 
@@ -279,6 +280,7 @@ function(corrosion_import_crate)
                     ${_CMAKE_CARGO_CONFIGURATION_TYPES}
                     ${crates_args}
                     --cargo-version ${_CORROSION_CARGO_VERSION}
+                    --rustflags "${COR_RUSTFLAGS}"
                     -o ${generated_cmake}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         RESULT_VARIABLE ret)

--- a/generator/src/subcommands/build_crate.rs
+++ b/generator/src/subcommands/build_crate.rs
@@ -61,7 +61,8 @@ pub fn invoke(
         .collect();
 
     if !languages.is_empty() {
-        let mut rustflags = "-C default-linker-libraries=yes".to_owned();
+        let mut rustflags = env::var("RUSTFLAGS").unwrap_or_default();
+        rustflags += " -C default-linker-libraries=yes";
 
         // This loop gets the highest preference link language to use for the linker
         let mut highest_preference: Option<(Option<i32>, &str)> = None;

--- a/generator/src/subcommands/gen_cmake.rs
+++ b/generator/src/subcommands/gen_cmake.rs
@@ -23,6 +23,7 @@ const CONFIGURATION_ROOT: &str = "configuration-root";
 const TARGET: &str = "target";
 const CARGO_VERSION: &str = "cargo-version";
 const CRATES: &str = "crates";
+const RUSTFLAGS: &str = "rustflags";
 
 pub fn subcommand() -> App<'static, 'static> {
     SubCommand::with_name(GEN_CMAKE)
@@ -89,6 +90,13 @@ pub fn subcommand() -> App<'static, 'static> {
                 .long("out-file")
                 .value_name("FILE")
                 .help("Output CMake file name. Defaults to stdout."),
+        )
+        .arg(
+            Arg::with_name(RUSTFLAGS)
+                .long(RUSTFLAGS)
+                .value_name(RUSTFLAGS)
+                .allow_hyphen_values(true)
+                .help("Rustflags to be supplied to Cargo when building."),
         )
 }
 
@@ -172,9 +180,10 @@ cmake_minimum_required (VERSION 3.12)
         })
         .collect();
 
+    let rustflags = matches.value_of(RUSTFLAGS).unwrap_or_default();
     for target in &targets {
         target
-            .emit_cmake_target(&mut out_file, &cargo_platform, &cargo_version)
+            .emit_cmake_target(&mut out_file, &cargo_platform, &cargo_version, &rustflags)
             .unwrap();
     }
 

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -103,6 +103,7 @@ impl CargoTarget {
         out_file: &mut dyn std::io::Write,
         platform: &super::platform::Platform,
         cargo_version: &semver::Version,
+        rustflags: &str,
     ) -> Result<(), Box<dyn Error>> {
         // This bit aggregates the byproducts of "cargo build", which is needed for generators like Ninja.
         let mut byproducts = vec![];
@@ -160,6 +161,7 @@ _add_cargo_build(
     TARGET {1}
     MANIFEST_PATH \"{2}\"
     BYPRODUCTS {3}
+    RUSTFLAGS \"{4}\"
 )
 ",
             self.cargo_package.name,
@@ -169,7 +171,8 @@ _add_cargo_build(
                 .to_str()
                 .unwrap()
                 .replace("\\", "/"),
-            byproducts.join(" ")
+            byproducts.join(" "),
+            rustflags,
         )?;
 
         match self.target_type {


### PR DESCRIPTION
This change allows the user to specify a set of `RUSTFLAGS` to be passed to Cargo when building by adding a `RUSTFLAGS` argument to `corrosion_import_crate`.

To support this, the generator's `gen_cmake` command was modified to accept an additional `--rustflags` argument that is then written to the generated CMake as a newly added argument to `_add_cargo_build`. When the generator's `build-crate` command is called, the `RUSTFLAGS` environment variable is set to the argument. Naturally, `build-crate` was modified to respect the environment variable.

Based on conversation in #80, I am using this to link to C libraries built/found by CMake. As an example:

```cmake
# CMakeLists.txt
find_package(foo REQUIRED)

set(LINK_DIRS)
foreach(lib IN LISTS foo_LIBRARIES)
    get_filename_component(dir "${lib}" DIRECTORY)
    list(APPEND LINK_DIRS "-L${dir}")
endforeach()
list(REMOVE_DUPLICATES LINK_DIRS)
string(REPLACE ";" " " LINK_DIRS "${LINK_DIRS}")

corrosion_import_crate(MANIFEST_PATH Cargo.toml RUSTFLAGS "${LINK_DIRS}")
```

```rust
// lib.rs
#[link(name = "foo")]
extern "C" { ... }
```