### PR TITLE
Attempt to fix CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
-          - macos-latest
+          - macos-10.15 # macos-11 is currently not working.
         arch:
           - x86_64
           - i686
@@ -69,11 +69,11 @@ jobs:
             generator: ninja
           - os: windows-latest
             arch: powerpc64le
-          - os: macos-latest
+          - os: macos-10.15
             arch: i686
-          - os: macos-latest
+          - os: macos-10.15
             arch: aarch64
-          - os: macos-latest
+          - os: macos-10.15
             arch: powerpc64le
 
           # ABI
@@ -83,14 +83,14 @@ jobs:
             abi: darwin
           - os: windows-latest
             abi: darwin
-          - os: macos-latest
+          - os: macos-10.15
             abi: msvc
-          - os: macos-latest
+          - os: macos-10.15
             abi: gnu
 
           # Rust
           # Build each set only with the earliest compatible versioned Rust
-          - os: macos-latest
+          - os: macos-10.15
             rust: 1.45.0
           - os: ubuntu-latest
             rust: 1.45.0
@@ -254,7 +254,7 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
-          - macos-latest
+          - macos-10.15
         method:
           - subdirectory
           - install

--- a/generator/src/subcommands/gen_cmake/platform.rs
+++ b/generator/src/subcommands/gen_cmake/platform.rs
@@ -41,6 +41,10 @@ impl Platform {
                         libs.extend_from_slice(&["shell32".to_string(), "kernel32".to_string()]);
                     }
 
+                    if version >= &Version::parse("1.57.0").unwrap() {
+                        libs.extend_from_slice(&["bcrypt".to_string()]);
+                    }
+
                     (libs, libs_debug, libs_release)
                 }
                 OS::MacOS => (


### PR DESCRIPTION
- Fix Building on Windows with Rust >= 1.57 by linking with Bcrypt.
- Test with MacOS 10.15 instead of `macos-latest`, since linking on MacOS 11 currently does not work. I don't have a mac, so I'm leaving it up to someone who has one to fix building on Macos 11.

#Closes 119