### PR TITLE
Improve documentation of Rust version related variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ The pairs can also be generator expressions, as they will be evaluated using $<G
 For example this may be useful if the build scripts of crates look for environment variables.
 This feature requires CMake >= 3.19.0.
 
+#### Information provided by Corrosion
+
+For your convenience, Corrosion sets a number of variables which contain information about the version of the rust 
+toolchain. You can use the CMake version comparison operators 
+(e.g. [`VERSION_GREATER_EQUAL`](https://cmake.org/cmake/help/latest/command/if.html#version-comparisons)) on the main
+variable (e.g. `if(Rust_VERSION VERSION_GREATER_EQUAL "1.57.0")`), or you can inspect the major, minor and patch 
+versions individually.
+- `Rust_VERSION<_MAJOR|_MINOR|_PATCH>` - The version of rustc.
+- `Rust_CARGO_VERSION<_MAJOR|_MINOR|_PATCH>` - The cargo version.
+- `Rust_LLVM_VERSION<_MAJOR|_MINOR|_PATCH>` - The LLVM version used by rustc.
+- `Rust_IS_NIGHTLY` - 1 if a nightly toolchain is used, otherwise 0. Useful for selecting an unstable feature for a 
+  crate, that is only available on nightly toolchains.
+
+### Cargo feature selection
+
 Cargo crates sometimes offer features, which traditionally can be specified with `cargo build` on the
 command line as opt-in. You can select the features to enable with the `FEATURES` argument when
 calling `corrosion_import_crate`. The following example enables the "chocolate" and "vanilla"
@@ -171,6 +186,7 @@ features, with the `--all-features` and `--no-default-features` options. Corrosi
 parameters for `corrosion_import_crate` called `ALL_FEATURES` and `NO_DEFAULT_FEATURES`. The corresponding
 boolean target properties - which override any specified values with `corrosion_import_crate` are called
 `CORROSION_ALL_FEATURES` and `CORROSION_NO_DEFAULT_FEATURES`.
+
 
 ### Developer/Maintainer Options
 These options are not used in the course of normal Corrosion usage, but are used to configure how

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -108,7 +108,7 @@ if (_RESOLVE_RUSTUP_TOOLCHAINS)
                 set(_TOOLCHAIN_OVERRIDE ${_TOOLCHAIN})
             endif()
         else()
-            message(WARNING "Didn't reconize toolchain: ${_TOOLCHAIN_RAW}")
+            message(WARNING "Didn't recognize toolchain: ${_TOOLCHAIN_RAW}")
         endif()
     endforeach()
 
@@ -158,7 +158,7 @@ if (_RESOLVE_RUSTUP_TOOLCHAINS)
     message(VERBOSE "Rust toolchain ${_RUSTUP_TOOLCHAIN_FULL}")
     message(VERBOSE "Rust toolchain path ${_RUST_TOOLCHAIN_PATH}")
 
-    # Is overrided if the user specifies `Rust_COMPILER` explicitly.
+    # Is overridden if the user specifies `Rust_COMPILER` explicitly.
     find_program(
         Rust_COMPILER_CACHED
         rustc

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -248,6 +248,18 @@ else()
     )
 endif()
 
+if (_RUSTC_VERSION_RAW MATCHES "LLVM version: ([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+    set(Rust_LLVM_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(Rust_LLVM_VERSION_MINOR "${CMAKE_MATCH_2}")
+    set(Rust_LLVM_VERSION_PATCH "${CMAKE_MATCH_3}")
+    set(Rust_LLVM_VERSION "${Rust_LLVM_VERSION_MAJOR}.${Rust_LLVM_VERSION_MINOR}.${Rust_LLVM_VERSION_PATCH}")
+else()
+    message(
+            WARNING
+            "Failed to parse rustc LLVM version. `rustc --version --verbose` evaluated to:\n${_RUSTC_VERSION_RAW}"
+    )
+endif()
+
 if (NOT Rust_CARGO_TARGET_CACHED)
     if (WIN32)
         if (CMAKE_VS_PLATFORM_NAME)

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -231,6 +231,8 @@ if (_RUSTC_VERSION_RAW MATCHES "rustc ([0-9]+)\\.([0-9]+)\\.([0-9]+)(-nightly)?"
     set(Rust_VERSION "${Rust_VERSION_MAJOR}.${Rust_VERSION_MINOR}.${Rust_VERSION_PATCH}")
     if(CMAKE_MATCH_4)
         set(Rust_IS_NIGHTLY 1)
+    else()
+        set(Rust_IS_NIGHTLY 0)
     endif()
 else()
     message(


### PR DESCRIPTION
- Document the version related variables that corrosion (FindRust) provides
- Improve the Rust_IS_NIGHTLY variable by always defining it (allows testing wether corrosion is new enough to set this variable)
- Add variables to expose the LLVM version used by rust. Useful e.g. for cross-language lto, where you want to be sure that the llvm version on both sides matches.