### PR TITLE
Release corrosion v0.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(Corrosion VERSION 0.0.1 LANGUAGES NONE)
+project(Corrosion VERSION 0.1.0 LANGUAGES NONE)
 
 # Default behavior:
 # - If the project is being used as a subdirectory, then don't build tests and

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,31 @@
+# 0.1.0 (2022-02-01)
+
+This is the first release of corrosion after it was moved to the new corrosion-rs organization.
+Since there are no previous releases, this is not a complete changelog but only lists changes since
+September 2021.
+
+## New features
+- [Add --profile support for rust >= 1.57](https://github.com/corrosion-rs/corrosion/pull/130):
+  Allows users to specify a custom cargo profile with 
+  `corrosion_import_crate(... PROFILE <profilename>)`.
+- [Add support for specifying per-target Rustflags](https://github.com/corrosion-rs/corrosion/pull/127):
+  Rustflags can be added via `corrosion_add_target_rustflags(<target_name> [rustflags1...])`
+- [Add `Rust_IS_NIGHTLY` and `Rust_LLVM_VERSION` variables](https://github.com/corrosion-rs/corrosion/pull/123):
+  This may be useful if you want to conditionally enabled features when using a nightly toolchain
+  or a specific LLVM Version.
+- [Let `FindRust` fail gracefully if rustc is not found](https://github.com/corrosion-rs/corrosion/pull/111):
+  This allows using `FindRust` in a more general setting (without corrosion).
+- [Add support for cargo feature selection](https://github.com/corrosion-rs/corrosion/pull/108):
+  See the [README](https://github.com/corrosion-rs/corrosion#cargo-feature-selection) for details on
+  how to select features.
+
+
+## Fixes
+- [Fix the cargo-clean target](https://github.com/corrosion-rs/corrosion/pull/129)
+- [Fix #84: CorrosionConfig.cmake looks in wrong place for Corrosion::Generator when CMAKE_INSTALL_LIBEXEC is an absolute path](https://github.com/corrosion-rs/corrosion/pull/122/commits/6f29af3ac53917ca2e0638378371e715a18a532d)
+- [Fix #116: (Option CORROSION_INSTALL_EXECUTABLE not working)](https://github.com/corrosion-rs/corrosion/commit/97d44018fac1b1a2a7c095288c628f5bbd9b3184)
+- [Fix building on Windows with rust >= 1.57](https://github.com/corrosion-rs/corrosion/pull/120)
+
+## Known issues:
+- Corrosion is currently not working on macos-11 and newer. See issue [#104](https://github.com/corrosion-rs/corrosion/issues/104).
+  Contributions are welcome.


### PR DESCRIPTION
Corrosions version has never been changed yet. Still, new features are
being added, and it would be great to update the version number from
time to time so we can use `find_package` to require a minimal version
number if we need some new corrosion feature.

Therefor I propose to bump the corrosion version number to 0.1.0 and
bump the patch version regularly if new features / bugfixes are added,
and bump the minor for breaking changes, including an increase of the
minimum supported cmake or rust version.

I'm aware that there are still open issues in the Project Plan for v0.1, but I think that this shouldn't keep us from releasing a new version from time to time. 

Any opinions on this?

