### PR TITLE
Fix corrosion_set_linker_language

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -146,7 +146,7 @@ function(_add_cargo_build)
         set(build_type_dir $<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:>>,debug,release>)
     endif()
 
-    set(target_linker_language "$<TARGET_PROPERTY:cargo-build_${target_name},LINKER_LANGUAGE>")
+    set(target_linker_language "$<TARGET_PROPERTY:cargo-build_${target_name},CARGO_LINKER_LANGUAGE>")
 
     # When cross-compiling, fall back to specifying at least the cross-compiling C linker, unless
     # an override is set.
@@ -362,7 +362,7 @@ endfunction(add_crate)
 function(corrosion_set_linker_language target_name language)
     set_property(
         TARGET cargo-build_${target_name}
-        PROPERTY LINKER_LANGUAGE ${language}
+        PROPERTY CARGO_LINKER_LANGUAGE ${language}
     )
 endfunction()
 

--- a/test/envvar/CMakeLists.txt
+++ b/test/envvar/CMakeLists.txt
@@ -1,4 +1,5 @@
 corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml)
+corrosion_set_linker_language(rust-lib-requiring-envvar C)
 
 set_property(
     TARGET rust-lib-requiring-envvar

--- a/test/envvar/build.rs
+++ b/test/envvar/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    assert!(!env!("CORROSION_LINKER_LANGUAGES").is_empty());
     assert_eq!(env!("REQUIRED_VARIABLE"), "EXPECTED_VALUE");
     assert_eq!(std::env::var("ANOTHER_VARIABLE").unwrap(), "ANOTHER_VALUE");
 }


### PR DESCRIPTION
It seems that LINKER_LANGUAGE of custom target in generator expression
is always empty so make it as custom property.