### PR TITLE
Add --profile support for rust >= 1.57

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,16 @@ parameters for `corrosion_import_crate` called `ALL_FEATURES` and `NO_DEFAULT_FE
 boolean target properties - which override any specified values with `corrosion_import_crate` are called
 `CORROSION_ALL_FEATURES` and `CORROSION_NO_DEFAULT_FEATURES`.
 
-#### RUSTFLAGS
+### Selecting a custom cargo profile
+
+[Rust 1.57](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html) stabilized the support for custom 
+[profiles](https://doc.rust-lang.org/cargo/reference/profiles.html). If you are using a sufficiently new rust toolchain,
+you may select a custom profile by adding the optional argument `PROFILE <profile_name>` to
+`corrosion_import_crate()`. If you do not specify a profile, or you use an older toolchain, corrosion will select
+the standard `dev` profile if the CMake config is either `Debug` or unspecified. In all other cases the `release`
+profile is chosen for cargo.
+
+### RUSTFLAGS
 
 Sometimes you may need to pass `RUSTFLAGS` to rustc, e.g. to enable some nightly option. Corrosion allows you to set
 RUSTFLAGS on a per-crate basis:

--- a/generator/src/subcommands/build_crate.rs
+++ b/generator/src/subcommands/build_crate.rs
@@ -6,6 +6,7 @@ pub const BUILD_CRATE: &str = "build-crate";
 
 // build-crate options
 const RELEASE: &str = "release";
+const PROFILE: &str = "profile";
 const PACKAGE: &str = "package";
 const TARGET: &str = "target";
 const RUSTFLAGS: &str = "rustflags";
@@ -18,6 +19,13 @@ const NO_DEFAULT_FEATURES: &str = "no-default-features";
 pub fn subcommand() -> App<'static, 'static> {
     SubCommand::with_name(BUILD_CRATE)
         .arg(Arg::with_name(RELEASE).long("release"))
+        .arg(
+            Arg::with_name(PROFILE)
+                .long("profile")
+                .takes_value(true)
+                .help("The cargo profile to build with, e.g. 'dev' or 'release'")
+                .conflicts_with(RELEASE)
+        )
         .arg(
             Arg::with_name(TARGET)
                 .long("target")
@@ -99,6 +107,11 @@ pub fn invoke(
 
     if matches.is_present(RELEASE) {
         cargo.arg("--release");
+    }
+
+    if matches.is_present(PROFILE) {
+        cargo.arg("--profile");
+        cargo.arg(matches.value_of(PROFILE).unwrap());
     }
 
     let mut rustflags = matches.value_of(RUSTFLAGS).unwrap_or_default().to_owned();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,10 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19.0)
     add_subdirectory(features)
 endif()
 
+if(Rust_VERSION VERSION_GREATER_EQUAL 1.57.0)
+    add_subdirectory(custom_profiles)
+endif()
+
 # Config tests don't work if this is the top level directory.
 if (NOT _TOP_LEVEL)
     add_subdirectory(config)

--- a/test/custom_profiles/CMakeLists.txt
+++ b/test/custom_profiles/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_release_profile $<IF:$<CONFIG:Release>,release-without-dbg,custom-without-dbg>)
+set(custom_profile $<IF:$<CONFIG:Debug>,dev-without-dbg,${_release_profile}>)
+
+corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml PROFILE ${custom_profile})
+
+add_executable(custom-profile-exe main.cpp)
+target_link_libraries(custom-profile-exe PUBLIC custom-profiles-lib)

--- a/test/custom_profiles/main.cpp
+++ b/test/custom_profiles/main.cpp
@@ -1,0 +1,6 @@
+extern "C" void rust_function(char const *name);
+
+
+int main(int argc, char **argv) {
+        rust_function("C++");
+}

--- a/test/custom_profiles/rust/Cargo.toml
+++ b/test/custom_profiles/rust/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "custom-profiles-lib"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["staticlib"]
+
+# Test if neither release or debug where selected by only disabling debug-assertions in the inherited profile.
+[profile.release]
+debug-assertions = true
+
+[profile.dev-without-dbg]
+inherits = "dev"
+debug-assertions = false
+
+[profile.release-without-dbg]
+inherits = "release"
+debug-assertions = false
+
+[profile.custom-without-dbg]
+inherits = "release"
+opt-level = 1
+debug-assertions = false

--- a/test/custom_profiles/rust/src/lib.rs
+++ b/test/custom_profiles/rust/src/lib.rs
@@ -1,0 +1,11 @@
+use std::os::raw::c_char;
+
+#[no_mangle]
+pub extern "C" fn rust_function(name: *const c_char) {
+    let name = unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() };
+    println!("Hello, {}! I'm Rust!", name);
+}
+
+
+#[cfg(debug_assertions)]
+const _: () = assert!(false, "Debug assertions where not disabled via custom profile!");


### PR DESCRIPTION
Add the option to specify the cargo profile by optionally specifying
CARGO_PROFILE when importing a crate. Cargo profiles are specified on
the workspace level, so it makes sense to select this option with
corrosion_import_crate.
This can be useful for specifying e.g. a `release-with-dbg` or
`release-with-lto` profile etc, that the user can then conditionally
select.

We currently do appear to conditionally link some libraries, depending
on the CMake build mode. So if the user selects a profile that requires
libraries, that are only linked in a different CMake build mode, then
this may cause issues for them. But I would label that a configuration
issue, that can be improved separately if it turns out to be necessary.
