### PR TITLE
Set CC and CXX for cargo

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -252,6 +252,17 @@ function(_add_cargo_build)
         list(APPEND features_args --features ${feature})
     endforeach()
 
+    # Todo: Refactor this together with the "$compilers section above."
+    if(CMAKE_C_COMPILER)
+        set(corrosion_cc "CC=${CMAKE_C_COMPILER}")
+    elseif(DEFINED ENV{CC})
+        set(corrosion_cc "CC=$ENV{CC}")
+    endif()
+    if(CMAKE_CXX_COMPILER)
+        set(corrosion_cxx "CXX=${CMAKE_CXX_COMPILER}")
+    elseif(DEFINED ENV{CXX})
+        set(corrosion_cc "CXX=$ENV{CXX}")
+    endif()
 
     add_custom_target(
         cargo-build_${target_name}
@@ -266,6 +277,8 @@ function(_add_cargo_build)
                 CORROSION_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
                 CORROSION_LINK_LIBRARIES=${link_libs}
                 CORROSION_LINK_DIRECTORIES=${search_dirs}
+                ${corrosion_cc}
+                ${corrosion_cxx}
                 ${corrosion_link_args}
                 ${link_prefs}
                 ${compilers}

--- a/test/envvar/CMakeLists.txt
+++ b/test/envvar/CMakeLists.txt
@@ -1,3 +1,7 @@
+# This test uses C++, so we can modify the C compiler to test if it is passed through as CC to 
+# cargo. Must be set before corrosion_import_crate.
+set(CMAKE_C_COMPILER "some-custom-c-compiler")
+
 corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml)
 
 set_property(

--- a/test/envvar/build.rs
+++ b/test/envvar/build.rs
@@ -1,4 +1,5 @@
 fn main() {
     assert_eq!(env!("REQUIRED_VARIABLE"), "EXPECTED_VALUE");
     assert_eq!(std::env::var("ANOTHER_VARIABLE").unwrap(), "ANOTHER_VALUE");
+    assert_eq!(env!("CC"), "some-custom-c-compiler");
 }


### PR DESCRIPTION
Cargo build scripts may themselves build c-dependencies and may choose
the compiler by inspecting CC or CXX.
Thus we should pass the compiler that was set in CMake, or alternatively
that is set in the environment to cargo.
This allows the build script to select the same compiler.

Closes #85