### PR TITLE
Fix Integrator build script

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -105,8 +105,13 @@ function(_add_cargo_build)
         set (build_dir .)
     endif()
 
-    set(link_libs "$<GENEX_EVAL:$<TARGET_PROPERTY:cargo-build_${target_name},CARGO_LINK_LIBRARIES>>")
-    set(search_dirs "$<GENEX_EVAL:$<TARGET_PROPERTY:cargo-build_${target_name},CARGO_LINK_DIRECTORIES>>")
+    # Join the list with `:` as a custom delimiter, since the `;` is expanded when passed
+    # to commands with COMMAND_EXPANDS_LISTS. File/directory paths may contain spaces, so we can't let
+    # the list be expanded.
+    set(_link_libs "$<GENEX_EVAL:$<TARGET_PROPERTY:cargo-build_${target_name},CARGO_LINK_LIBRARIES>>")
+    set(link_libs "$<JOIN:${_link_libs},:>")
+    set(_search_dirs "$<GENEX_EVAL:$<TARGET_PROPERTY:cargo-build_${target_name},CARGO_LINK_DIRECTORIES>>")
+    set(search_dirs "$<JOIN:${_search_dirs},:>")
 
     # For MSVC targets, don't mess with linker preferences.
     # TODO: We still should probably make sure that rustc is using the correct cl.exe to link programs.
@@ -273,9 +278,9 @@ function(_add_cargo_build)
         COMMAND
             ${CMAKE_COMMAND} -E env
                 ${build_env_variable_genex}
-                CORROSION_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
-                CORROSION_LINK_LIBRARIES=${link_libs}
-                CORROSION_LINK_DIRECTORIES=${search_dirs}
+                CORROSION_BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}"
+                CORROSION_LINK_LIBRARIES="${link_libs}"
+                CORROSION_LINK_DIRECTORIES="${search_dirs}"
                 ${corrosion_cc}
                 ${corrosion_cxx}
                 ${corrosion_link_args}

--- a/integrator/src/lib.rs
+++ b/integrator/src/lib.rs
@@ -9,19 +9,21 @@ pub fn build_script() {
 
     let search_dirs: Vec<_> = std::env::var("CORROSION_LINK_DIRECTORIES")
         .iter()
-        .flat_map(|v| v.split(";").map(std::string::ToString::to_string))
+        .flat_map(|v| v.split(':').map(std::string::ToString::to_string))
         .collect();
 
     let libraries: Vec<_> = std::env::var("CORROSION_LINK_LIBRARIES")
         .iter()
-        .flat_map(|v| v.split(";").map(std::string::ToString::to_string))
+        .flat_map(|v| v.split(':').map(std::string::ToString::to_string))
         .collect();
 
     for dir in &search_dirs {
+        // can be eliminated if we directly add the rustflag "-L<dir>".
         println!("cargo:rustc-link-search={}", dir);
     }
 
     for library in &libraries {
+        // can be eliminated if we directly add the rustflag "-l<library>".
         println!("cargo:rustc-link-lib={}", library);
     }
 }

--- a/test/cpp2rust/CMakeLists.txt
+++ b/test/cpp2rust/CMakeLists.txt
@@ -1,10 +1,26 @@
 corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml)
-corrosion_link_libraries(rust-exe cpp-lib)
+corrosion_link_libraries(rust-exe cpp-lib cpp-lib2 cpp-lib3)
 
 add_library(cpp-lib lib.cpp)
 target_compile_features(cpp-lib PRIVATE cxx_std_17)
 set_target_properties(
     cpp-lib
     PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+)
+
+add_library(cpp-lib2 lib2.cpp )
+target_compile_features(cpp-lib2 PRIVATE cxx_std_17)
+set_target_properties(
+        cpp-lib2
+        PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+)
+
+add_library(cpp-lib3 "path with space/lib3.cpp" )
+target_compile_features(cpp-lib3 PRIVATE cxx_std_17)
+set_target_properties(
+        cpp-lib3
+        PROPERTIES
         POSITION_INDEPENDENT_CODE ON
 )

--- a/test/cpp2rust/lib2.cpp
+++ b/test/cpp2rust/lib2.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include <string_view>
+
+extern "C" void cpp_function2(char const *name) {
+    std::string_view const name_sv = name;
+    std::cout << "Hello, " << name_sv << "! I'm C++ library Number 2!\n";
+}
+

--- a/test/cpp2rust/path with space/lib3.cpp
+++ b/test/cpp2rust/path with space/lib3.cpp
@@ -1,0 +1,10 @@
+// Check that libraries located at a path containing a space can also be linked.
+
+#include <iostream>
+#include <string_view>
+
+extern "C" void cpp_function3(char const *name) {
+    std::string_view const name_sv = name;
+    std::cout << "Hello, " << name_sv << "! I'm C++ library Number 3!\n";
+}
+

--- a/test/cpp2rust/rust/src/main.rs
+++ b/test/cpp2rust/rust/src/main.rs
@@ -1,13 +1,18 @@
-use std::os::raw::{c_char};
+use std::os::raw::c_char;
 
 extern "C" {
     fn cpp_function(name: *const c_char);
+    fn cpp_function2(name: *const c_char);
+    fn cpp_function3(name: *const c_char);
+
 }
 
 fn greeting(name: &str) {
     let name = std::ffi::CString::new(name).unwrap();
     unsafe {
         cpp_function(name.as_ptr());
+        cpp_function2(name.as_ptr());
+        cpp_function3(name.as_ptr());
     }
 }
 


### PR DESCRIPTION
We use `COMMAND_EXPAND_LISTS`, which also expands lists in generator
expressions. Therefore the values of the env variables will be space
seperated.

Closes #128
