### PR TITLE
Don't set linker language for corrosion generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,6 @@ endif()
 # Builds the generator executable
 corrosion_import_crate(MANIFEST_PATH generator/Cargo.toml)
 
-# Set the link language to CXX since it's already enabled
-corrosion_set_linker_language(corrosion-generator CXX)
 
 if (IS_ABSOLUTE ${CMAKE_INSTALL_LIBEXECDIR})
     set(_CORROSION_GENERATOR_DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")


### PR DESCRIPTION
The corrosion generator is a 100% rust executable, so I don't think there is any benefit in us telling rust which linker it should use.

Additionally corrosion_set_linker_language currently does not have any effect anyway (See #133).

Closes #88
