### PR TITLE
Fix windows-latest CI issues

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches:
       - '**'
-defaults:
-  run:
-    shell: bash
 jobs:
   test:
     name: Test Corrosion
@@ -66,6 +63,18 @@ jobs:
             cmake: 3.20.0
             rust: stable
             generator: ninja-multiconfig
+          - os: windows-2022
+            arch: aarch64
+            abi: msvc
+            cmake: 3.21.5 # Earliest supported version for VS 17 in windows-2022
+            rust: "1.54" # Minimum supported rust version for cross-compile with Windows MSVC
+            generator: default
+          - os: windows-2022
+            arch: i686
+            abi: msvc
+            cmake: 3.21.5 # Earliest supported version for VS 17 in windows-2022
+            rust: "1.54" # Minimum supported rust version for cross-compile with Windows MSVC
+            generator: default
 
         exclude:
 
@@ -96,6 +105,25 @@ jobs:
           - os: macos-12
             arch: powerpc64le
 
+          # Cross-compiling is broken on Windows with MSVC before 1.54, since build-scripts are cross-linked instead
+          # of being linked for the host platform.
+          - os: windows-2019
+            abi: msvc
+            rust: 1.46.0
+            arch: i686
+          - os: windows-2019
+            abi: msvc
+            rust: 1.46.0
+            arch: aarch64
+          - os: windows-2022
+            abi: msvc
+            rust: 1.46.0
+            arch: i686
+          - os: windows-2022
+            abi: msvc
+            rust: 1.46.0
+            arch: aarch64
+
           # ABI
           - os: ubuntu-latest
             abi: msvc
@@ -113,12 +141,18 @@ jobs:
             os: macos-12
           - rust: 1.54.0
             os: windows-2019
+            abi: gnu
+          - rust: 1.54.0
+            os: windows-2019
+            abi: msvc
+            arch: x86_64
           - rust: 1.54.0
             os: ubuntu-latest
 
     steps:
       - name: Determine Rust OS
         id: determine_rust_os
+        shell: bash
         run: |
           if [ "${{ runner.os }}" == "Windows" ]; then
             echo "::set-output name=os::pc-windows"
@@ -132,6 +166,7 @@ jobs:
           fi
       - name: Pick Compiler
         id: pick_compiler
+        shell: bash
         run: |
           if [ "${{ matrix.abi }}" == "gnu" ]; then
             if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
@@ -151,16 +186,18 @@ jobs:
           fi
       - name: Pick Generator
         id: pick_generator
+        shell: bash
         run: |
           if [ "${{ matrix.generator }}" == "ninja" ]; then
             echo "::set-output name=generator::-GNinja"
           elif [ "${{ matrix.generator }}" == "ninja-multiconfig" ];then
-            echo "::set-output name=generator::-G \"Ninja Multi-Config\""
+            echo "::set-output name=generator::-GNinja Multi-Config"
           elif [ "${{ matrix.abi }}" == "default" ]; then
             echo "::set-output name=generator::"
           fi
       - name: Arch Flags
         id: arch_flags
+        shell: bash
         run: | # Cross-compiling is currently only supported on Windows+MSVC with the default generator
           if [ "${{ runner.os }}" == "Windows" ]; then
             if [ "${{matrix.generator}}" == "default" ]; then
@@ -182,7 +219,7 @@ jobs:
             echo "::set-output name=cmake::-DRust_CARGO_TARGET=${{matrix.arch}}-${{steps.determine_rust_os.outputs.os}}-${{matrix.abi}}"
           fi
       - name: Setup MSVC Development Environment
-        uses: ilammy/msvc-dev-cmd@v1.4.1
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ steps.arch_flags.outputs.msvc }}
         if: ${{ 'msvc' == matrix.abi }}
@@ -209,18 +246,19 @@ jobs:
       - name: Configure
         run: >
           cmake
-          -S.
-          -Bbuild
-          -DCORROSION_VERBOSE_OUTPUT=ON
-          ${{ steps.arch_flags.outputs.cmake }}
-          ${{ steps.pick_compiler.outputs.c_compiler }}
-          ${{ steps.pick_compiler.outputs.cxx_compiler }}
-          ${{ steps.pick_compiler.outputs.system_name }}
-          ${{ steps.pick_generator.outputs.generator }}
-          -DRust_TOOLCHAIN="${{matrix.rust}}"
+          "-S."
+          "-Bbuild"
+          "-DCORROSION_VERBOSE_OUTPUT=ON"
+          "${{steps.arch_flags.outputs.cmake}}"
+          "${{steps.pick_compiler.outputs.c_compiler}}"
+          "${{steps.pick_compiler.outputs.cxx_compiler}}"
+          "${{steps.pick_compiler.outputs.system_name}}"
+          "${{steps.pick_generator.outputs.generator}}"
+          "-DRust_TOOLCHAIN=${{matrix.rust}}"
       - name: Run Tests
-        run: |
+        run: >
           cd build
+          
           ctest --verbose --build-config Debug
 
   install:
@@ -239,6 +277,9 @@ jobs:
             rust: 1.54.0  # On MacOS-12 linking fails before Rust 1.54
     steps:
       - uses: actions/checkout@v2
+      - name: Setup MSVC Development Environment
+        uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
       - name: Install CMake
         uses: corrosion-rs/install-cmake@v1.1
         with:
@@ -266,7 +307,7 @@ jobs:
           ctest --output-on-failure -C Debug
       - name: Test Corrosion as installed module
         run: >
-          rm -rf build
+          cmake -E remove_directory build
 
           cmake
           -S.

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -71,6 +71,14 @@ if(Rust_TOOLCHAIN_IS_RUSTUP_MANAGED)
 
 endif()
 
+if(CMAKE_GENERATOR MATCHES "Visual Studio"
+        AND (NOT CMAKE_VS_PLATFORM_NAME STREQUAL CMAKE_VS_PLATFORM_NAME_DEFAULT)
+        AND Rust_VERSION VERSION_LESS "1.54")
+    message(FATAL_ERROR "Due to a cargo issue, cross-compiling with a Visual Studio generator and rust versions"
+            " before 1.54 is not supported. Rust build scripts would be linked with the cross-compiler linker, which"
+            " causes the build to fail. Please upgrade your Rust version to 1.54 or newer.")
+endif()
+
 if (NOT TARGET Corrosion::Generator)
     message(STATUS "Using Corrosion as a subdirectory")
 endif()


### PR DESCRIPTION
- Replace undocumented `cmake -H` option with `cmake -S`, since `-H` is aliased with `--help` on more recent cmake versions.
- Use the default shell in CI where possible, which means powershell on windows. This is required because git bash [does not work](https://github.com/marketplace/actions/enable-developer-command-prompt#name-conflicts-with-shell-bash) with the `msvc-dev-cmd` action we need for msvc. 
- Use Yaml `>`  syntax to replace line continuations with spaces for long commands. Powershell line continuation is space +  backtick, so we can't just use `\`.