### PR TITLE
Use corrosion-rs fork of install-cmake

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -181,7 +181,7 @@ jobs:
         if: ${{ 'msvc' == matrix.abi }}
       - uses: actions/checkout@v2
       - name: Install CMake
-        uses: AndrewGaspar/install-cmake@master
+        uses: corrosion-rs/install-cmake@v1.1
         with:
           cmake: ${{matrix.cmake}}
           ninja: 1.10.0


### PR DESCRIPTION
To support CMake version >= 3.20 in CI, we should use the
updated fork. The download url format changed with cmake 3.20
so I updated the action to take that into account and return
the right url depending on the version.

I also saw there is the `get_cmake` action this action is partially
based on, but since that only supports one hardcoded version, it
would be hard to integrate into our CI workflow I think.