### PR TITLE
Fix macos 11 build

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -543,6 +543,10 @@ function(corrosion_link_libraries target_name)
             $<TARGET_PROPERTY:${library},LINKER_LANGUAGE>
         )
         corrosion_add_target_rustflags(${target_name} "-L$<TARGET_LINKER_FILE_DIR:${library}>")
+        if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            corrosion_add_target_rustflags(${target_name} "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib")
+        endif()
+        
 
         # TODO: The output name of the library can be overridden - find a way to support that.
         corrosion_add_target_rustflags(${target_name} "-l${library}")


### PR DESCRIPTION
This is a workaround fix for macos 11, seems you need to add the library path from `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib`, I cannot figure out where is the proper place to put this search dir flag, so feel free to edit.