### PR TITLE
Fix macos-11 for CMake >= 3.19

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         os:
           - windows-2019 # windows-latest is currently not having a supported MSVC compiler
           - ubuntu-latest
-          - macos-10.15 # macos-11 is currently not working.
+          - macos-10.15
         arch:
           - x86_64
           - i686
@@ -42,6 +42,19 @@ jobs:
         generator:
           - default # This is just whatever the platform default is
           - ninja
+        include:
+          - os: macos-latest
+            arch: x86_64
+            abi: darwin
+            cmake: 3.19.0
+            rust: 1.44.1
+            generator: default
+          - os: macos-latest
+            arch: x86_64
+            abi: darwin
+            cmake: 3.19.0
+            rust: stable
+            generator: ninja
         exclude:
           # Something's busted when building with Visual Studio with CMake 3.12 - perhaps should
           # look into this at some point

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -275,6 +275,11 @@ function(_generator_add_target manifest ix cargo_version profile)
                     TARGET ${target_name}-static
                     PROPERTY INTERFACE_LINK_LIBRARIES ${libs}
                 )
+                if(is_macos)
+                    set_property(TARGET ${target_name}-static
+                            PROPERTY INTERFACE_LINK_DIRECTORIES "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+                    )
+                endif()
             endif()
 
             if(libs_debug)
@@ -297,6 +302,11 @@ function(_generator_add_target manifest ix cargo_version profile)
         if(has_cdylib)
             add_library(${target_name}-shared SHARED IMPORTED GLOBAL)
             add_dependencies(${target_name}-shared cargo-build_${target_name})
+            if(is_macos)
+                set_property(TARGET ${target_name}-shared
+                        PROPERTY INTERFACE_LINK_DIRECTORIES "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+                        )
+            endif()
         endif()
 
         add_library(${target_name} INTERFACE)
@@ -315,6 +325,11 @@ function(_generator_add_target manifest ix cargo_version profile)
     elseif(is_executable)
         add_executable(${target_name} IMPORTED GLOBAL)
         add_dependencies(${target_name} cargo-build_${target_name})
+        if(is_macos)
+            set_property(TARGET ${target_name}
+                    PROPERTY INTERFACE_LINK_DIRECTORIES "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+            )
+        endif()
     else()
         message(FATAL_ERROR "unknown target type")
     endif()


### PR DESCRIPTION
Fix Corrosion on macOS >=11 by adding the necessary link directory if
using the experimental parser. There is technical reason preventing
a backport to the older generator (except that the property
INTERFACE_LINK_DIRECTORIES requires CMake >= 3.13), so future work
could add support for older CMake versions.
For now I think its fine requiring a recent CMake version for recent
macOS versions.

Closes #104