### PR TITLE
Don't generate .cargo/config

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -263,7 +263,8 @@ function(_add_cargo_build)
         set(cargo_profile $<$<NOT:$<OR:$<CONFIG:Debug>,$<CONFIG:>>>:--release>)
     endif()
 
-    set(cargo_build_dir "${CMAKE_BINARY_DIR}/${build_dir}/cargo/build/${target_artifact_dir}/${build_type_dir}")
+    set(cargo_target_dir "${CMAKE_BINARY_DIR}/${build_dir}/cargo/build")
+    set(cargo_build_dir "${cargo_target_dir}/${target_artifact_dir}/${build_type_dir}")
     set(build_byproducts)
     set(byproducts)
     foreach(byproduct_file ${ACB_BYPRODUCTS})
@@ -362,6 +363,7 @@ function(_add_cargo_build)
             ${features_genex}
             --package ${package_name}
             --manifest-path "${path_to_toml}"
+            --target-dir "${cargo_target_dir}"
             ${cargo_profile}
 
     # Copy crate artifacts to the binary dir

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -422,8 +422,8 @@ function(_generator_add_cargo_targets)
     endif()
 
     foreach(folder ${config_folders})
-        if(NOT EXISTS "${folder}/.cargo/config")
-            message(FATAL_ERROR "Target config_folder '${folder}' must contain a '.cargo/config'.")
+        if(NOT EXISTS "${folder}")
+            file(MAKE_DIRECTORY ${folder})
         endif()
     endforeach()
 

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -347,45 +347,9 @@ endforeach()
 find_package_handle_standard_args(
     Rust
     REQUIRED_VARS Rust_COMPILER Rust_VERSION Rust_CARGO Rust_CARGO_VERSION Rust_CARGO_TARGET Rust_CARGO_HOST_TARGET
-    VERSION_VAR Rust_VERSION)
+    VERSION_VAR Rust_VERSION
+)
 
-function(_gen_config config_type use_config_dir)
-    string(TOUPPER "${config_type}" _UPPER_CONFIG_TYPE)
-
-    if(use_config_dir)
-        set(_DESTINATION_DIR ${CMAKE_BINARY_DIR}/${CMAKE_VS_PLATFORM_NAME}/${config_type})
-    else()
-        set(_DESTINATION_DIR ${CMAKE_BINARY_DIR})
-    endif()
-
-    set(_CARGO_CONFIG ${_DESTINATION_DIR}/.cargo/config)
-
-    file(WRITE ${_CARGO_CONFIG}
-"\
-[build]
-target-dir=\"cargo/build\"
-")
-
-    string(REPLACE ";" "\", \"" _RUSTFLAGS "${CARGO_RUST_FLAGS}" "${CARGO_RUST_FLAGS_${_UPPER_CONFIG_TYPE}}")
-
-    if (_RUSTFLAGS)
-        file(APPEND ${_CARGO_CONFIG}
-            "rustflags = [\"${_RUSTFLAGS}\"]\n")
-    endif()
-
-    get_filename_component(_moddir ${CMAKE_CURRENT_LIST_FILE} DIRECTORY)
-endfunction(_gen_config)
-
-if (CMAKE_CONFIGURATION_TYPES)
-    foreach(config_type ${CMAKE_CONFIGURATION_TYPES})
-        _gen_config(${config_type} ON)
-    endforeach()
-elseif(CMAKE_BUILD_TYPE)
-    _gen_config(${CMAKE_BUILD_TYPE} OFF)
-else()
-    message(STATUS "Defaulting Cargo to build debug")
-    _gen_config(Debug OFF)
-endif()
 
 if(NOT TARGET Rust::Rustc)
     add_executable(Rust::Rustc IMPORTED GLOBAL)

--- a/generator/src/subcommands/gen_cmake.rs
+++ b/generator/src/subcommands/gen_cmake.rs
@@ -150,21 +150,11 @@ cmake_minimum_required(VERSION 3.15)
     if let Some(config_types) = matches.values_of(CONFIGURATION_TYPES) {
         for config_type in config_types {
             let config_folder = config_root.join(config_type);
-            assert!(
-                config_folder.join(".cargo/config").exists(),
-                "Target config_folder '{}' must contain a '.cargo/config'.",
-                config_folder.display()
-            );
             config_folders.push((Some(config_type), config_folder));
         }
     } else {
         let config_type = matches.value_of(CONFIGURATION_TYPE);
         let config_folder = config_root;
-        assert!(
-            config_folder.join(".cargo/config").exists(),
-            "Target config_folder '{}' must contain a '.cargo/config'.",
-            config_folder.display()
-        );
         config_folders.push((config_type, config_folder.to_path_buf()));
     }
 

--- a/generator/src/subcommands/gen_cmake.rs
+++ b/generator/src/subcommands/gen_cmake.rs
@@ -150,6 +150,7 @@ cmake_minimum_required(VERSION 3.15)
     if let Some(config_types) = matches.values_of(CONFIGURATION_TYPES) {
         for config_type in config_types {
             let config_folder = config_root.join(config_type);
+            std::fs::create_dir_all(&config_folder).expect("Could not create config folder");
             config_folders.push((Some(config_type), config_folder));
         }
     } else {
@@ -197,16 +198,7 @@ cmake_minimum_required(VERSION 3.15)
 
     writeln!(out_file)?;
 
-    let metadata_manifest_path = Path::new(&args.metadata.workspace_root).join("Cargo.toml");
-
-    for (config_type, config_folder) in config_folders {
-        let current_dir = std::env::current_dir().expect("Could not get current directory!");
-        std::env::set_current_dir(config_folder)
-            .expect("Could not change directory to the Config directory!");
-
-        let mut local_metadata_cmd = cargo_metadata::MetadataCommand::new();
-        local_metadata_cmd.manifest_path(Path::new(&metadata_manifest_path));
-
+    for (config_type, _config_folder) in config_folders {
         for target in &targets {
             target.emit_cmake_config_info(
                 &mut out_file,
@@ -215,9 +207,6 @@ cmake_minimum_required(VERSION 3.15)
                 &config_type,
             )?;
         }
-
-        std::env::set_current_dir(current_dir)
-            .expect("Could not return to the build root directory!")
     }
 
     std::process::exit(0);

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -102,7 +102,7 @@ impl CargoTarget {
         &self,
         out_file: &mut dyn std::io::Write,
         platform: &super::platform::Platform,
-        cargo_version: &semver::Version,
+        _cargo_version: &semver::Version,
         cargo_profile: Option<&str>,
         include_platform_libs: bool,
     ) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
It's better to pass the arguments directly on the commandline.

This is a first step towards allowing the working directory for cargo
build to be set by the user, which would allow the user to use a
.cargo/config.toml themselves