### PR TITLE
Fix compilation of projects using cc-rs on macOS

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -278,6 +278,13 @@ function(_add_cargo_build)
     if(DEFINED ENV{CXX})
         list(APPEND corrosion_cc_rs_flags "HOST_CXX=$ENV{CXX}")
     endif()
+    # Since we instruct cc-rs to use the compiler found by CMake, it is likely one that requires also
+    # specifying the target sysroot to use. CMake's generator makes sure to pass --sysroot with
+    # CMAKE_OSX_SYSROOT. Fortunately the compilers Apple ships also respect the SDKROOT environment
+    # variable, which we can set for use when cc-rs invokes the compiler.
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_SYSROOT)
+        list(APPEND corrosion_cc_rs_flags "SDKROOT=${CMAKE_OSX_SYSROOT}")
+    endif()
 
     corrosion_add_target_rustflags("${target_name}" "$<$<BOOL:${corrosion_link_args}>:-Clink-args=${corrosion_link_args}>")
 


### PR DESCRIPTION
After commit 0b0b182f8d2e12a1558d12dc5aea15bc815c703b, cc-rs now invokes
the compiler found by CMake, for example

    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc

instead of

    /usr/bin/cc

The latter uses the default SDK sysroot root as configured with xcode.
The latter requires either specifying --sysroot /path/to/sysroot (which
is what CMake does) or it falls back to using the SDKROOT environment
variable. Without a sysroot the compiler can't find standard includes.

This patch sets SDKROOT as environment variable to be set during cargo
invocation, to the same value that CMake passes to the compiler. That
way cc-rs won't need any additional flags.

cc #152