### PR TITLE
Respect OUTPUT_NAME when linking targets that have it defined

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -597,10 +597,9 @@ function(corrosion_link_libraries target_name)
             PROPERTY CARGO_DEPS_LINKER_LANGUAGES
             $<TARGET_PROPERTY:${library},LINKER_LANGUAGE>
         )
-        corrosion_add_target_rustflags(${target_name} "-L$<TARGET_LINKER_FILE_DIR:${library}>")
 
-        # TODO: The output name of the library can be overridden - find a way to support that.
-        corrosion_add_target_rustflags(${target_name} "-l${library}")
+        corrosion_add_target_rustflags(${target_name} "-L$<TARGET_LINKER_FILE_DIR:${library}>")
+        corrosion_add_target_rustflags(${target_name} "-l$<TARGET_LINKER_FILE_BASE_NAME:${library}>")
     endforeach()
 endfunction(corrosion_link_libraries)
 

--- a/test/cpp2rust/CMakeLists.txt
+++ b/test/cpp2rust/CMakeLists.txt
@@ -1,5 +1,4 @@
 corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml)
-corrosion_link_libraries(rust-exe cpp-lib cpp-lib2 cpp-lib3)
 
 add_library(cpp-lib lib.cpp)
 target_compile_features(cpp-lib PRIVATE cxx_std_14)
@@ -15,6 +14,7 @@ set_target_properties(
         cpp-lib2
         PROPERTIES
         POSITION_INDEPENDENT_CODE ON
+        OUTPUT_NAME cpp-lib-renamed
 )
 
 add_library(cpp-lib3 "path with space/lib3.cpp" )
@@ -24,3 +24,5 @@ set_target_properties(
         PROPERTIES
         POSITION_INDEPENDENT_CODE ON
 )
+
+corrosion_link_libraries(rust-exe cpp-lib cpp-lib2 cpp-lib3)


### PR DESCRIPTION
This causes the OUTPUT_NAME target_property to be used when passing the
-l flag to corrosion_link_libraries. However, if any users have
corrosion_link_libraries(MyRustExe LibA) in their CMakeLists before the
target LibA is defined, it will now error out because the target is not
defined yet.

Fixes #172 

I'm not sure if this technically breaking change is ok. It definitely seems non-idiomatic to me to link against a library before it's been declared as a target, especially if you're going to set OUTPUT_NAME on it or other properties... but I can go back and wrap the get_property in an if(TARGET ${library}) if it's preferred.