### PR TITLE
Downgrade warning to status if no linker pref. is found

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -311,7 +311,7 @@ function(_add_cargo_build)
             corrosion_add_target_rustflags("${target_name}" "-Clink-args=--target=${CORROSION_LINKER_PREFERENCE_TARGET}")
         endif()
     else()
-        message(WARNING "No linker preference for target ${target_name}")
+        message(STATUS "No linker preference for target ${target_name} could be detected.")
     endif()
 
     # Remove the target triple from the rust toolchain (which may or may not be present).


### PR DESCRIPTION
There may be no linker preference if the user has no language enabled
in CMake, or no specific compiler selected for a language.
This may be a problem for users who link their library into Rust, but
is not a problem for the other direction.
To remove false warnings downgrade the message to STATUS.
If the wrong linker (language) is selected for Rust code, this should
also cause the link step to fail anyway, and the status should point in the right direction.

Closes #176