### PR TITLE
Corrosion tests should not test C++ features not used by Corrosion it…

### DIFF
--- a/test/cpp2rust/CMakeLists.txt
+++ b/test/cpp2rust/CMakeLists.txt
@@ -2,7 +2,7 @@ corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml)
 corrosion_link_libraries(rust-exe cpp-lib cpp-lib2 cpp-lib3)
 
 add_library(cpp-lib lib.cpp)
-target_compile_features(cpp-lib PRIVATE cxx_std_17)
+target_compile_features(cpp-lib PRIVATE cxx_std_14)
 set_target_properties(
     cpp-lib
     PROPERTIES
@@ -10,7 +10,7 @@ set_target_properties(
 )
 
 add_library(cpp-lib2 lib2.cpp )
-target_compile_features(cpp-lib2 PRIVATE cxx_std_17)
+target_compile_features(cpp-lib2 PRIVATE cxx_std_14)
 set_target_properties(
         cpp-lib2
         PROPERTIES
@@ -18,7 +18,7 @@ set_target_properties(
 )
 
 add_library(cpp-lib3 "path with space/lib3.cpp" )
-target_compile_features(cpp-lib3 PRIVATE cxx_std_17)
+target_compile_features(cpp-lib3 PRIVATE cxx_std_14)
 set_target_properties(
         cpp-lib3
         PROPERTIES

--- a/test/cpp2rust/lib.cpp
+++ b/test/cpp2rust/lib.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
 
 extern "C" void cpp_function(char const *name) {
-    std::cout << "Hello, " << "my name is lib.cpp" << "! I'm C++!\n";
+    std::cout << "Hello, " << name << "! I'm C++!\n";
 }

--- a/test/cpp2rust/lib.cpp
+++ b/test/cpp2rust/lib.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
-#include <string_view>
 
 extern "C" void cpp_function(char const *name) {
-    std::string_view const name_sv = name;
-    std::cout << "Hello, " << name_sv << "! I'm C++!\n";
+    std::cout << "Hello, " << "my name is lib.cpp" << "! I'm C++!\n";
 }

--- a/test/cpp2rust/lib2.cpp
+++ b/test/cpp2rust/lib2.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
-#include <string_view>
 
 extern "C" void cpp_function2(char const *name) {
-    std::string_view const name_sv = name;
-    std::cout << "Hello, " << name_sv << "! I'm C++ library Number 2!\n";
+    std::cout << "Hello, " << "my name is lib2.cpp" << "! I'm C++ library Number 2!\n";
 }
 

--- a/test/cpp2rust/lib2.cpp
+++ b/test/cpp2rust/lib2.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
 extern "C" void cpp_function2(char const *name) {
-    std::cout << "Hello, " << "my name is lib2.cpp" << "! I'm C++ library Number 2!\n";
+    std::cout << "Hello, " << name << "! I'm C++ library Number 2!\n";
 }
 

--- a/test/cpp2rust/path with space/lib3.cpp
+++ b/test/cpp2rust/path with space/lib3.cpp
@@ -1,10 +1,8 @@
 // Check that libraries located at a path containing a space can also be linked.
 
 #include <iostream>
-#include <string_view>
 
 extern "C" void cpp_function3(char const *name) {
-    std::string_view const name_sv = name;
-    std::cout << "Hello, " << name_sv << "! I'm C++ library Number 3!\n";
+    std::cout << "Hello, " << "my name is lib3.cpp" << "! I'm C++ library Number 3!\n";
 }
 

--- a/test/cpp2rust/path with space/lib3.cpp
+++ b/test/cpp2rust/path with space/lib3.cpp
@@ -3,6 +3,6 @@
 #include <iostream>
 
 extern "C" void cpp_function3(char const *name) {
-    std::cout << "Hello, " << "my name is lib3.cpp" << "! I'm C++ library Number 3!\n";
+    std::cout << "Hello, " << name << "! I'm C++ library Number 3!\n";
 }
 


### PR DESCRIPTION
…self.

This PR follows discussion for #183.

* Problem addressed with this PR:
- CMakeLists.txt uses std_cxx_17 to compile it's test cases.
- Tests cases need std_cxx_17, because of their use of <string_view>.
Because of both, Corrosion fails to compile on 'old' systems (I did not say vintage :-)).

* Investigations:
As Corrosion does not use <string_view>, it's not needed to use this in its test cases.
If <string_view> is not used anywhere, options std_cxx_17 are no more required.

* Correction proposal:
Use of std_cxx_14, instead of std_cxx_17.
Remove the use of <string_view> in Corrosion test cases.
Altogether, this allows older compilers to build Corrosion.

* Remark:
This PR keeps some std_cxx_14 (instead of _17) to keep the need of C++ Standard Library installed on the compilation host.
I did not test, but I suppose std_cxx_11 would work too.