### PR TITLE
Add `LINKER_LANGUAGE` option to `corrosion_import_crate`

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -130,7 +130,7 @@ endif()
 
 function(_add_cargo_build)
     set(options "")
-    set(one_value_args PACKAGE TARGET MANIFEST_PATH PROFILE LINKER_LANGUAGE)
+    set(one_value_args PACKAGE TARGET MANIFEST_PATH PROFILE LINK_AS)
     set(multi_value_args BYPRODUCTS)
     cmake_parse_arguments(
         ACB
@@ -160,8 +160,8 @@ function(_add_cargo_build)
     # For MSVC targets, don't mess with linker preferences.
     # TODO: We still should probably make sure that rustc is using the correct cl.exe to link programs.
     if (NOT MSVC)
-        if (ACB_LINKER_LANGUAGE)
-            set(languages ${ACB_LINKER_LANGUAGE})
+        if (ACB_LINK_AS)
+            set(languages ${ACB_LINK_AS})
         else()
             set(languages C CXX Fortran)
         endif()
@@ -395,7 +395,7 @@ endfunction(_add_cargo_build)
 
 function(corrosion_import_crate)
     set(OPTIONS ALL_FEATURES NO_DEFAULT_FEATURES NO_STD)
-    set(ONE_VALUE_KEYWORDS MANIFEST_PATH PROFILE LINKER_LANGUAGE)
+    set(ONE_VALUE_KEYWORDS MANIFEST_PATH PROFILE LINK_AS)
     set(MULTI_VALUE_KEYWORDS CRATES FEATURES)
     cmake_parse_arguments(COR "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}" ${ARGN})
 
@@ -404,8 +404,8 @@ function(corrosion_import_crate)
     endif()
 
     set(valid_languages C CXX Fortran)
-    if ((DEFINED COR_LINKER_LANGUAGE) AND (NOT COR_LINKER_LANGUAGE IN_LIST valid_languages))
-        message(FATAL_ERROR "LINKER_LANGUAGE may only be set to one of ${valid_languages}.")
+    if ((DEFINED COR_LINK_AS) AND (NOT COR_LINK_AS IN_LIST valid_languages))
+        message(FATAL_ERROR "LINK_AS may only be set to one of ${valid_languages}.")
     endif()
 
     if(COR_PROFILE)
@@ -474,8 +474,8 @@ function(corrosion_import_crate)
             list(APPEND crates_args --crates ${crate})
         endforeach()
 
-        if (COR_LINKER_LANGUAGE)
-            set(linker_language "--linker-language=${COR_LINKER_LANGUAGE}")
+        if (COR_LINK_AS)
+            set(link_as "--linker-language=${COR_LINK_AS}")
         endif()
 
         execute_process(
@@ -488,7 +488,7 @@ function(corrosion_import_crate)
                         ${_CORROSION_CONFIGURATION_TYPES}
                         ${crates_args}
                         ${cargo_profile}
-                        ${linker_language}
+                        ${link_as}
                         ${no_default_libs_arg}
                         --cargo-version ${_CORROSION_CARGO_VERSION}
                         -o ${generated_cmake}
@@ -518,8 +518,8 @@ function(corrosion_import_crate)
                 "${COR_CRATES}"
             PROFILE
                 "${COR_PROFILE}"
-            LINKER_LANGUAGE
-                "${COR_LINKER_LANGUAGE}"
+            LINK_AS
+                "${COR_LINK_AS}"
         )
     endif()
 endfunction(corrosion_import_crate)

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -198,7 +198,7 @@ function(_generator_parse_target manifest package target)
     )
 endfunction()
 
-function(_generator_add_target manifest ix cargo_version profile linker_language)
+function(_generator_add_target manifest ix cargo_version profile link_as)
     get_source_file_property(package_name ${manifest} CORROSION_TARGET${ix}_PACKAGE_NAME)
     get_source_file_property(manifest_path ${manifest} CORROSION_TARGET${ix}_MANIFEST_PATH)
     get_source_file_property(target_name ${manifest} CORROSION_TARGET${ix}_TARGET_NAME)
@@ -332,7 +332,7 @@ function(_generator_add_target manifest ix cargo_version profile linker_language
             MANIFEST_PATH "${manifest_path}"
             BYPRODUCTS ${byproducts}
             PROFILE "${profile}"
-            LINKER_LANGUAGE ${linker_language}
+            LINK_AS ${link_as}
     )
 endfunction()
 
@@ -399,7 +399,7 @@ endfunction()
 
 function(_generator_add_cargo_targets)
     set(options "")
-    set(one_value_args MANIFEST_PATH CONFIGURATION_ROOT CONFIGURATION_TYPE TARGET CARGO_VERSION PROFILE LINKER_LANGUAGE)
+    set(one_value_args MANIFEST_PATH CONFIGURATION_ROOT CONFIGURATION_TYPE TARGET CARGO_VERSION PROFILE LINK_AS)
     set(multi_value_args CONFIGURATION_TYPES CRATES)
     cmake_parse_arguments(
         GGC
@@ -482,7 +482,7 @@ function(_generator_add_cargo_targets)
             ${ix}
             ${GGC_CARGO_VERSION}
             "${GGC_PROFILE}"
-            "${GGC_LINKER_LANGUAGE}"
+            "${GGC_LINK_AS}"
         )
     endforeach()
 

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -198,7 +198,7 @@ function(_generator_parse_target manifest package target)
     )
 endfunction()
 
-function(_generator_add_target manifest ix cargo_version profile)
+function(_generator_add_target manifest ix cargo_version profile linker_language)
     get_source_file_property(package_name ${manifest} CORROSION_TARGET${ix}_PACKAGE_NAME)
     get_source_file_property(manifest_path ${manifest} CORROSION_TARGET${ix}_MANIFEST_PATH)
     get_source_file_property(target_name ${manifest} CORROSION_TARGET${ix}_TARGET_NAME)
@@ -332,6 +332,7 @@ function(_generator_add_target manifest ix cargo_version profile)
             MANIFEST_PATH "${manifest_path}"
             BYPRODUCTS ${byproducts}
             PROFILE "${profile}"
+            LINKER_LANGUAGE ${linker_language}
     )
 endfunction()
 
@@ -398,7 +399,7 @@ endfunction()
 
 function(_generator_add_cargo_targets)
     set(options "")
-    set(one_value_args MANIFEST_PATH CONFIGURATION_ROOT CONFIGURATION_TYPE TARGET CARGO_VERSION PROFILE)
+    set(one_value_args MANIFEST_PATH CONFIGURATION_ROOT CONFIGURATION_TYPE TARGET CARGO_VERSION PROFILE LINKER_LANGUAGE)
     set(multi_value_args CONFIGURATION_TYPES CRATES)
     cmake_parse_arguments(
         GGC
@@ -481,6 +482,7 @@ function(_generator_add_cargo_targets)
             ${ix}
             ${GGC_CARGO_VERSION}
             "${GGC_PROFILE}"
+            "${GGC_LINKER_LANGUAGE}"
         )
     endforeach()
 

--- a/generator/src/subcommands/gen_cmake.rs
+++ b/generator/src/subcommands/gen_cmake.rs
@@ -23,7 +23,7 @@ const CONFIGURATION_ROOT: &str = "configuration-root";
 const TARGET: &str = "target";
 const CARGO_VERSION: &str = "cargo-version";
 const PROFILE: &str = "profile";
-const LINKER_LANGUAGE: &str = "linker-language";
+const LINK_AS: &str = "linker-language";
 const CRATES: &str = "crates";
 const NO_DEFAULT_LIBRARIES: &str = "no-default-libraries";
 
@@ -94,9 +94,9 @@ pub fn subcommand() -> App<'static, 'static> {
                 .help("Custom cargo profile to select."),
         )
         .arg(
-            Arg::with_name(LINKER_LANGUAGE)
-                .long(LINKER_LANGUAGE)
-                .value_name("LINKER_LANGUAGE")
+            Arg::with_name(LINK_AS)
+                .long(LINK_AS)
+                .value_name("LINK_AS")
                 .required(false)
                 .possible_values(&["C", "CXX", "Fortran"])
                 .help("Language to select a linker by: C, CXX or Fortran.")
@@ -201,7 +201,7 @@ cmake_minimum_required(VERSION 3.15)
         .collect();
 
     let cargo_profile = matches.value_of(PROFILE);
-    let linker_language = matches.value_of(LINKER_LANGUAGE);
+    let link_as = matches.value_of(LINK_AS);
 
     for target in &targets {
         target
@@ -210,7 +210,7 @@ cmake_minimum_required(VERSION 3.15)
                 &cargo_platform,
                 &cargo_version,
                 cargo_profile,
-                linker_language,
+                link_as,
                 !matches.is_present(NO_DEFAULT_LIBRARIES),
             )
             .unwrap();

--- a/generator/src/subcommands/gen_cmake.rs
+++ b/generator/src/subcommands/gen_cmake.rs
@@ -23,6 +23,7 @@ const CONFIGURATION_ROOT: &str = "configuration-root";
 const TARGET: &str = "target";
 const CARGO_VERSION: &str = "cargo-version";
 const PROFILE: &str = "profile";
+const LINKER_LANGUAGE: &str = "linker-language";
 const CRATES: &str = "crates";
 const NO_DEFAULT_LIBRARIES: &str = "no-default-libraries";
 
@@ -91,6 +92,14 @@ pub fn subcommand() -> App<'static, 'static> {
                 .value_name("PROFILE")
                 .required(false)
                 .help("Custom cargo profile to select."),
+        )
+        .arg(
+            Arg::with_name(LINKER_LANGUAGE)
+                .long(LINKER_LANGUAGE)
+                .value_name("LINKER_LANGUAGE")
+                .required(false)
+                .possible_values(&["C", "CXX", "Fortran"])
+                .help("Language to select a linker by: C, CXX or Fortran.")
         )
         .arg(
             Arg::with_name(OUT_FILE)
@@ -192,6 +201,7 @@ cmake_minimum_required(VERSION 3.15)
         .collect();
 
     let cargo_profile = matches.value_of(PROFILE);
+    let linker_language = matches.value_of(LINKER_LANGUAGE);
 
     for target in &targets {
         target
@@ -200,6 +210,7 @@ cmake_minimum_required(VERSION 3.15)
                 &cargo_platform,
                 &cargo_version,
                 cargo_profile,
+                linker_language,
                 !matches.is_present(NO_DEFAULT_LIBRARIES),
             )
             .unwrap();

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -104,7 +104,7 @@ impl CargoTarget {
         platform: &super::platform::Platform,
         cargo_version: &semver::Version,
         cargo_profile: Option<&str>,
-        linker_language: Option<&str>,
+        link_as: Option<&str>,
         include_platform_libs: bool,
     ) -> Result<(), Box<dyn Error>> {
         // This bit aggregates the byproducts of "cargo build", which is needed for generators like Ninja.
@@ -161,8 +161,8 @@ impl CargoTarget {
             String::default()
         };
 
-        let linker_language_option = if let Some(linker_language) = linker_language {
-            format!("LINKER_LANGUAGE {}", linker_language)
+        let link_as_option = if let Some(link_as) = link_as {
+            format!("LINK_AS {}", link_as)
         }
         else {
             String::default()
@@ -286,7 +286,7 @@ _add_cargo_build(
             self.cargo_package.manifest_path.as_str().replace("\\", "/"),
             byproducts.join(" "),
             cargo_build_profile_option,
-            linker_language_option
+            link_as_option
         )?;
 
         writeln!(out_file)?;

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -104,6 +104,7 @@ impl CargoTarget {
         platform: &super::platform::Platform,
         cargo_version: &semver::Version,
         cargo_profile: Option<&str>,
+        linker_language: Option<&str>,
         include_platform_libs: bool,
     ) -> Result<(), Box<dyn Error>> {
         // This bit aggregates the byproducts of "cargo build", which is needed for generators like Ninja.
@@ -157,6 +158,13 @@ impl CargoTarget {
         let cargo_build_profile_option = if let Some(profile) = cargo_profile {
             format!("PROFILE {}", profile)
         } else {
+            String::default()
+        };
+
+        let linker_language_option = if let Some(linker_language) = linker_language {
+            format!("LINKER_LANGUAGE {}", linker_language)
+        }
+        else {
             String::default()
         };
 
@@ -270,13 +278,15 @@ _add_cargo_build(
     MANIFEST_PATH \"{2}\"
     BYPRODUCTS {3}
     {4}
+    {5}
 )
 ",
             self.cargo_package.name,
             self.cargo_target.name,
             self.cargo_package.manifest_path.as_str().replace("\\", "/"),
             byproducts.join(" "),
-            cargo_build_profile_option
+            cargo_build_profile_option,
+            linker_language_option
         )?;
 
         writeln!(out_file)?;


### PR DESCRIPTION
# Background and Linker Problem

I am developing a library that is intended to be consumed by both C and C++.
The library's core logic is written in Rust, exporting a `.h` C header and an optional wrapper `.hpp` C++ header, with tests in C++.

I've started using corrosion to integrate calling `cargo` with CMake, but noticed (investigating with `ldd` on Linux and `otool -L` on MacOS) that the corrosion-cargo-built binary depended on the C++ standard library.

The C++ dependency is absent when invoking `cargo` on the command line directly and is introduced by corrosion when it sets the `CORROSION_LINKER_PREFERENCE` variable `cmake/Corrosion.cmake` which is eventually passed to `cargo` as `CARGO_TARGET_...._LINKER=path/to/cpp_compiler`. Reading the code, this logic is skipped when building on Windows with MSVC.

It is a hard requirement for my project that the rust-built library does not depend on C++, as such I've started adding a feature to corrosion to specify which language's linker to pass into the `cargo` invocation.

# Approach

The approach I'm taking is to add an optional `LINKER_LANGUAGE` parameter to `corrosion_import_crate`. For my needs, this ends up looking like so:

```
corrosion_import_crate(
    MANIFEST_PATH Cargo.toml
    FEATURES ffi
    LINKER_LANGUAGE C)
```

Does this make sense?

P.S.: I've also noticed there's a `corrosion_set_linker_language` CMake function, but it didn't seem to do anything relevant to my problem.

# State of this pull request

I'm raising a draft pull request because, frankly, I'm still learning CMake and I expect more changes are needed before this can be merged in.

## Testing

So far I've re-run a subset of the existing tests locally on Linux as so:

```
# Prepare for testing
rm -fR build
cmake \
  -S . \
  -B build \
  -DCORROSION_VERBOSE_OUTPUT=ON \
  -DCMAKE_C_COMPILER=gcc \
  -DCMAKE_CXX_COMPILER=g++ \
  -GNinja

# Run Config Tests (x86_64 Only)
(cd build &&
cmake \
  --build . --verbose \
  --target test-install
ctest --verbose --build-config Debug)

# Build C++ program linking Rust
(cmake \
  --build build --verbose \
  --target cpp-exe)

# Build Rust program linking C++
(cmake \
  --build build --verbose \
  --target cargo-build_rust-exe)

# Build Rust cdylib and link against C++
(cmake \
  --build build --verbose \
  --target my_program)
```

This is not exhausitve, but I think it's unlikely I've broken anything.

I certainly haven't tested the new feature though, aside from the low bar of "it works for me".

I would appreciate some guidance on how to progress, especially on the testing front:
* Would this be a new directory under `test/`?
* Should I create different tests to with and without the native tools or is this somehow handled by the github actions workflow matrix?
* Any idea on how to actually assert if a cargo built library doesn't have a C++ dependency from CMake -- pretty clueless here.

## Docs
There's also a matter of documentation: The "LINKER_LANGUAGE" feature would be de facto Mac/Linux only.
Is it OK to just document (and maybe log) that the named argument is ignored on Windows/MSVC?

## Naming
Should the parameter name here be changed? Would `LINK_AS` be a better name to avoid creating confusion with the already existing `corrosion_set_linker_language` cmake function (that I don't really understand the intended purpose of)?

Thanks!


