### PR TITLE
Use macos-12 in github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         os:
           - windows-2019 # windows-latest is currently not having a supported MSVC compiler
           - ubuntu-latest
-          - macos-10.15
+          - macos-12
         arch:
           - x86_64
           - i686
@@ -41,19 +41,6 @@ jobs:
         generator:
           - default # This is just whatever the platform default is
           - ninja
-        include:
-          - os: macos-latest
-            arch: x86_64
-            abi: darwin
-            cmake: 3.19.0
-            rust: 1.44.1
-            generator: default
-          - os: macos-latest
-            arch: x86_64
-            abi: darwin
-            cmake: 3.19.0
-            rust: stable
-            generator: ninja
         exclude:
 
           # You cannot build with GNU using Visual Studio on Windows
@@ -76,11 +63,11 @@ jobs:
             generator: ninja
           - os: windows-2019
             arch: powerpc64le
-          - os: macos-10.15
+          - os: macos-12
             arch: i686
-          - os: macos-10.15
+          - os: macos-12
             arch: aarch64
-          - os: macos-10.15
+          - os: macos-12
             arch: powerpc64le
 
           # ABI
@@ -90,14 +77,14 @@ jobs:
             abi: darwin
           - os: windows-2019
             abi: darwin
-          - os: macos-10.15
+          - os: macos-12
             abi: msvc
-          - os: macos-10.15
+          - os: macos-12
             abi: gnu
 
           # Rust
           # Build each set only with the earliest compatible versioned Rust
-          - os: macos-10.15
+          - os: macos-12
             rust: 1.45.0
           - os: ubuntu-latest
             rust: 1.45.0
@@ -257,7 +244,7 @@ jobs:
         os:
           - windows-2019
           - ubuntu-latest
-          - macos-10.15
+          - macos-12
         method:
           - subdirectory
           - install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,7 @@ jobs:
           - 3.15.7
           - 3.19.0
         rust:
-          - 1.44.1 # Earliest targeted version
-          - 1.45.0 # Earliest version compatible with Windows GNU
+          - 1.46.0 # MSRV Minimum supported rust version
           - stable
           - nightly
         generator:
@@ -81,21 +80,6 @@ jobs:
             abi: msvc
           - os: macos-12
             abi: gnu
-
-          # Rust
-          # Build each set only with the earliest compatible versioned Rust
-          - os: macos-12
-            rust: 1.45.0
-          - os: ubuntu-latest
-            rust: 1.45.0
-          - os: windows-2019
-            abi: msvc
-            rust: 1.45.0
-          # Prior to 1.45.0, -nostdlib is erroneously passed to g++ when for the *-pc-windows-gnu
-          # target. See: https://github.com/rust-lang/rust/pull/71769
-          - os: windows-2019
-            abi: gnu
-            rust: 1.44.1
 
     steps:
       - name: Determine Rust OS
@@ -266,7 +250,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.44.1
+          toolchain: 1.46.0
           default: true
       - name: CMake Version
         run: cmake --version

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,10 +1,17 @@
+# Unreleased
+
+# Breaking
+
+- The minimum supported rust version was increased to 1.46, due to a cargo issue that recently
+  surfaced on CI when using crates.io.
+
 # 0.2.1 (2022-05-07)
 
 ## Fixes
 
 - Fix missing variables provided by corrosion, when corrosion is used as a subdirectory ([181](https://github.com/corrosion-rs/corrosion/pull/181)):
   Public [Variables](https://github.com/corrosion-rs/corrosion#information-provided-by-corrosion) set
-  by Corrosion were not visible when using Corrosion as a subdirectory, due to the wrong scope of 
+  by Corrosion were not visible when using Corrosion as a subdirectory, due to the wrong scope of
   the variables. This was fixed by promoting the respective variables to Cache variables.
 
 # 0.2.0 (2022-05-05)
@@ -24,7 +31,7 @@
     `corrosion_set_features()`. See the updated Readme for details.
   - `CORROSION_ENVIRONMENT_VARIABLES`. Please use `corrosion_set_env_vars()` instead.
   - `CORROSION_USE_HOST_BUILD`. Please use `corrosion_set_hostbuild()` instead.
-- The Minimum CMake version will likely be increased for the next major release. At the very least we want to drop 
+- The Minimum CMake version will likely be increased for the next major release. At the very least we want to drop
   support for CMake 3.12, but requiring CMake 3.16 or even 3.18 is also on the table. If you are using a CMake version
   that would be no longer supported by corrosion, please comment on issue
   [#168](https://github.com/corrosion-rs/corrosion/issues/168), so that we can gauge the number of affected users.
@@ -33,7 +40,7 @@
 
 - Add `NO_STD` option to `corrosion_import_crate` ([#154](https://github.com/corrosion-rs/corrosion/pull/154)).
 - Remove the requirement of building the Rust based generator crate for CMake >= 3.19. This makes using corrosion as
-  a subdirectory as fast as the installed version (since everything is done in CMake). 
+  a subdirectory as fast as the installed version (since everything is done in CMake).
   ([#131](https://github.com/corrosion-rs/corrosion/pull/131), [#161](https://github.com/corrosion-rs/corrosion/pull/161))
   If you do choose to install Corrosion, then by default the old Generator is still compiled and installed, so you can
   fall back to using it in case you use multiple cmake versions on the same machine for different projects.
@@ -44,13 +51,13 @@
   [#164](https://github.com/corrosion-rs/corrosion/pull/164)).
 - Improve robustness of parsing the LLVM version (exported in `Rust_LLVM_VERSION`). It now also works for
   Rust versions, where the LLVM version is reported as `MAJOR.MINOR`. ([#148](https://github.com/corrosion-rs/corrosion/pull/148))
-- Fix a bug which occurred when Corrosion was added multiple times via `add_subdirectory()` 
+- Fix a bug which occurred when Corrosion was added multiple times via `add_subdirectory()`
   ([#143](https://github.com/corrosion-rs/corrosion/pull/143)).
-- Set `CC_<target_triple_undercore>` and `CXX_<target_triple_undercore>` environment variables for the invocation of 
-  `cargo build` to the compilers selected by CMake  (if any) 
+- Set `CC_<target_triple_undercore>` and `CXX_<target_triple_undercore>` environment variables for the invocation of
+  `cargo build` to the compilers selected by CMake  (if any)
   ([#138](https://github.com/corrosion-rs/corrosion/pull/138) and [#161](https://github.com/corrosion-rs/corrosion/pull/161)).
   This should ensure that C dependencies built in cargo buildscripts via [cc-rs](https://github.com/alexcrichton/cc-rs)
-  use the same compiler as CMake built dependencies. Users can override the compiler by specifying the higher 
+  use the same compiler as CMake built dependencies. Users can override the compiler by specifying the higher
   priority environment variable variants with dashes instead of underscores (See cc-rs documentation for details).
 - Fix Ninja-Multiconfig Generator support for CMake versions >= 3.20. Previous CMake versions are missing a feature,
   which prevents us from supporting the Ninja-Multiconfig generator. ([#137](https://github.com/corrosion-rs/corrosion/pull/137))
@@ -64,7 +71,7 @@ September 2021.
 
 ## New features
 - [Add --profile support for rust >= 1.57](https://github.com/corrosion-rs/corrosion/pull/130):
-  Allows users to specify a custom cargo profile with 
+  Allows users to specify a custom cargo profile with
   `corrosion_import_crate(... PROFILE <profilename>)`.
 - [Add support for specifying per-target Rustflags](https://github.com/corrosion-rs/corrosion/pull/127):
   Rustflags can be added via `corrosion_add_target_rustflags(<target_name> [rustflags1...])`

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -247,10 +247,7 @@ function(_generator_add_target manifest ix cargo_version profile)
     # Only shared libraries and executables have PDBs on Windows
     # We don't know why PDBs aren't generated for staticlibs...
     if(is_windows_msvc AND (has_cdylib OR is_executable))
-        if(cargo_version VERSION_LESS "1.45.0")
-            set(prefix "deps/")
-        endif()
-        list(APPEND byproducts "${prefix}${pdb_name}")
+        list(APPEND byproducts "${pdb_name}")
     endif()
 
     if(is_library)

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -130,14 +130,6 @@ impl CargoTarget {
             }
         }
 
-        // Cargo didn't place PDBs in the target output directory before 1.45, so copy them out
-        // of the deps/ folder instead
-        let prefix = if cargo_version < &semver::Version::new(1, 45, 0) {
-            "deps/"
-        } else {
-            ""
-        };
-
         // Only shared libraries and executables have PDBs on Windows
         // I don't know why PDBs aren't generated for staticlibs...
         let has_pdb = platform.is_windows()
@@ -151,7 +143,7 @@ impl CargoTarget {
             };
 
         if has_pdb {
-            byproducts.push(prefix.to_string() + &self.pdb_name());
+            byproducts.push(self.pdb_name());
         }
 
         let cargo_build_profile_option = if let Some(profile) = cargo_profile {


### PR DESCRIPTION
macos-10.15 is deprecated and will be removed at the end of next month
according to this announcement: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

Use the newest available version macos-12 in github actions instead.

Additionally the MSRV is raised to 1.46, since apparently a change at crates.io surfaced an old cargo bug which was fixed in cargo 1.46.