### PR TITLE
Fix Rustflags test

### DIFF
--- a/test/rustflags/CMakeLists.txt
+++ b/test/rustflags/CMakeLists.txt
@@ -8,6 +8,6 @@ corrosion_add_target_rustflags(rustflag-test-lib "--cfg=test_rustflag_cfg1=\\\"t
 
 # Test using a generator expression to produce a rustflag and passing multiple rustflags.
 corrosion_add_target_rustflags(rustflag-test-lib
-        "--cfg=test_rustflag_cfg2=\\\"$<IF:$<CONFIG:Release>,release,debug>\\\""
+        "--cfg=test_rustflag_cfg2=\\\"$<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:>>,debug,release>\\\""
         "--cfg=test_rustflag_cfg3"
 )


### PR DESCRIPTION
Corrosion selects Debug mode if Debug mode or nothing is specified and Release mode
for all other CMake build types.
This commit fixes the rustflags test for other build modes, where
Corrosion selected the release build mode for cargo.
Selecting a custom cargo profile will still cause issues for this test,
but there is not really a reason to do that when building corrosion,
so this can still be improved later.