### PR TITLE
Switch `cargo build` working directory to the Manifest (cargo.toml) directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build*/
 install*/
 .vscode
+.idea

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,11 @@
 - The minimum supported rust version was increased to 1.46, due to a cargo issue that recently
   surfaced on CI when using crates.io.
 
+# Potentially breaking
+
+- The working directory when invoking `cargo build` was changed to the directory of the Manifest
+  file. This now allows cargo to pick up `.cargo/config.toml` files located in the source tree.
+
 # 0.2.1 (2022-05-07)
 
 ## Fixes

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -148,6 +148,7 @@ function(_add_cargo_build)
     if (NOT IS_ABSOLUTE "${path_to_toml}")
         set(path_to_toml "${CMAKE_SOURCE_DIR}/${path_to_toml}")
     endif()
+    get_filename_component(workspace_toml_dir ${path_to_toml} DIRECTORY )
 
     if (CMAKE_VS_PLATFORM_NAME)
         set (build_dir "${CMAKE_VS_PLATFORM_NAME}/$<CONFIG>")
@@ -379,9 +380,9 @@ function(_add_cargo_build)
     COMMAND
         ${CMAKE_COMMAND} -E copy_if_different ${build_byproducts} ${target_dir}
     BYPRODUCTS ${byproducts}
-    # The build is conducted in root build directory so that cargo
-    # dependencies are shared
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${build_dir}
+    # The build is conducted in the directory of the Manifest, so that configuration files such as
+    # `.cargo/config.toml` or `toolchain.toml` are applied as expected.
+    WORKING_DIRECTORY "${workspace_toml_dir}"
     USES_TERMINAL
     COMMAND_EXPAND_LISTS
     )

--- a/test/envvar/.cargo/config.toml
+++ b/test/envvar/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+COR_CONFIG_TOML_ENV_VAR = "EnvVariableSetViaConfig.toml"

--- a/test/envvar/CMakeLists.txt
+++ b/test/envvar/CMakeLists.txt
@@ -3,6 +3,8 @@ corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml)
 corrosion_set_env_vars(rust-lib-requiring-envvar
         "ANOTHER_VARIABLE=ANOTHER_VALUE"
         "$<TARGET_PROPERTY:program_requiring_rust_lib_with_envvar,INDIRECT_VAR_TEST>"
+        "COR_CARGO_VERSION_MAJOR=${Rust_CARGO_VERSION_MAJOR}"
+        "COR_CARGO_VERSION_MINOR=${Rust_CARGO_VERSION_MINOR}"
 )
 
 add_executable(program_requiring_rust_lib_with_envvar main.cpp)

--- a/test/envvar/build.rs
+++ b/test/envvar/build.rs
@@ -1,4 +1,18 @@
 fn main() {
     assert_eq!(env!("REQUIRED_VARIABLE"), "EXPECTED_VALUE");
     assert_eq!(std::env::var("ANOTHER_VARIABLE").unwrap(), "ANOTHER_VALUE");
+    let cargo_major = env!("COR_CARGO_VERSION_MAJOR")
+        .parse::<u32>()
+        .expect("Invalid Major version");
+    let cargo_minor = env!("COR_CARGO_VERSION_MINOR")
+        .parse::<u32>()
+        .expect("Invalid Minor version");
+
+    // The `[env]` section in `.cargo/config.toml` was added in version 1.56.
+    if cargo_major > 1 || (cargo_major == 1 && cargo_minor >= 56) {
+        // Check if cargo picks up the config.toml, which sets this additional env variable.
+        let env_value = option_env!("COR_CONFIG_TOML_ENV_VAR")
+            .expect("Test failure! Cargo >= 1.56.0 should set this environment variable");
+        assert_eq!(env_value, "EnvVariableSetViaConfig.toml");
+    }
 }


### PR DESCRIPTION
The output directory (target-dir) is left unchanged.
Changing the cwd to the directory of the Manifest, has the advantage that
cargo can pick up `.cargo/config.toml` files in the source tree.
In the future this would also allow corrosion to respect `rust-toolchain.toml`
and other rustup toolchain overrides.

Closes #150 

