### PR TITLE
Allow explicitly selecting the linker for a rust target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if (CORROSION_GENERATOR_EXECUTABLE)
     set(CORROSION_INSTALL_EXECUTABLE_DEFAULT OFF)
 # If corrosion is used as a subdirectory, the CMake version is recent enough and the option is not
 # explicitly disabled, then we do not need to build the Rust based parser and use the CMake based
-# parser instead. `CORROSION_EXPERIMENTAL_PARSER` is a deprecated inverted version of 
+# parser instead. `CORROSION_EXPERIMENTAL_PARSER` is a deprecated inverted version of
 # `CORROSION_NATIVE_TOOLING` and will be removed in version 0.3
 elseif((NOT _CORROSION_TOP_LEVEL)
         AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.19.0
@@ -93,10 +93,7 @@ if(CORROSION_INSTALL_EXECUTABLE)
     # Builds the generator executable
     corrosion_import_crate(MANIFEST_PATH generator/Cargo.toml)
 
-    # Set the link language to CXX since it's already enabled
-    corrosion_set_linker_language(corrosion-generator CXX)
-
-set(_CORROSION_GENERATOR_DESTINATION "${CMAKE_INSTALL_FULL_LIBEXECDIR}")
+    set(_CORROSION_GENERATOR_DESTINATION "${CMAKE_INSTALL_FULL_LIBEXECDIR}")
 
     corrosion_install(
         TARGETS corrosion-generator

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,12 @@
 
 - The working directory when invoking `cargo build` was changed to the directory of the Manifest
   file. This now allows cargo to pick up `.cargo/config.toml` files located in the source tree.
+- Corrosion internally invokes `cargo build`. When passing arguments to `cargo build`, Corrosion
+  now uses the CMake `VERBATIM` option. In rare cases this may require you to change how you quote
+  parameters passed to corrosion (e.g. via `corrosion_add_target_rustflags()`).
+  For example setting a `cfg` option previously required double escaping the rustflag like this
+  `"--cfg=something=\\\"value\\\""`, but now it can be passed to corrosion without any escapes:
+  `--cfg=something="value"`.
 
 # 0.2.1 (2022-05-07)
 

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -7,12 +7,12 @@ endif()
 
 option(CORROSION_VERBOSE_OUTPUT "Enables verbose output from Corrosion and Cargo" OFF)
 
-set(CORROSION_NATIVE_TOOLING_DESCRIPTION 
+set(CORROSION_NATIVE_TOOLING_DESCRIPTION
     "Use native tooling - Required on CMake < 3.19 and available as a fallback option for recent versions"
     )
 
 set(CORROSION_NATIVE_TOOLING_DEFAULT OFF)
-# `CORROSION_EXPERIMENTAL_PARSER` was not part of a tagged release, but we still provide a 
+# `CORROSION_EXPERIMENTAL_PARSER` was not part of a tagged release, but we still provide a
 # deprecation notice for users that directly use corrosion on the master branch and may have set
 # this option.
 if(DEFINED CORROSION_EXPERIMENTAL_PARSER)
@@ -224,7 +224,6 @@ function(_add_cargo_build)
     # `rustflags_target_property` may contain multiple arguments and double quotes, so we _should_ single quote it to
     # preserve any double quotes and keep it as one argument value. However single quotes don't work on windows, so we
     # can only add double quotes here. Any double quotes _in_ the rustflags must be escaped like `\\\"`.
-    set(rustflags_genex "$<$<BOOL:${rustflags_target_property}>:--rustflags=\"${rustflags_target_property}\">")
 
     set(features_target_property "$<GENEX_EVAL:$<TARGET_PROPERTY:${target_name},${_CORR_PROP_FEATURES}>>")
     set(features_genex "$<$<BOOL:${features_target_property}>:--features=$<JOIN:${features_target_property},$<COMMA>>>")
@@ -324,7 +323,8 @@ function(_add_cargo_build)
         corrosion_add_target_rustflags("${target_name}" "-Cdefault-linker-libraries=yes")
     endif()
 
-    set(rustflags_genex_test "$<$<BOOL:${rustflags_target_property}>:RUSTFLAGS=\"${rustflags_target_property}\">")
+    set(joined_rustflags "$<JOIN:${rustflags_target_property}, >")
+    set(rustflags_genex "$<$<BOOL:${rustflags_target_property}>:RUSTFLAGS=${joined_rustflags}>")
 
     if(CORROSION_LINKER_PREFERENCE)
         if(CMAKE_CROSSCOMPILING)
@@ -352,13 +352,13 @@ function(_add_cargo_build)
     # Build crate
     COMMAND
         ${CMAKE_COMMAND} -E env
-            ${build_env_variable_genex}
-            ${rustflags_genex_test}
-            ${cargo_target_linker}
-            ${corrosion_cc_rs_flags}
-            ${cargo_library_path}
-            CORROSION_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
-            CARGO_BUILD_RUSTC="${_CORROSION_RUSTC}"
+            "${build_env_variable_genex}"
+            "${rustflags_genex}"
+            "${cargo_target_linker}"
+            "${corrosion_cc_rs_flags}"
+            "${cargo_library_path}"
+            "CORROSION_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+            "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
         "${_CORROSION_CARGO}"
             build
             ${cargo_target_option}
@@ -385,6 +385,7 @@ function(_add_cargo_build)
     WORKING_DIRECTORY "${workspace_toml_dir}"
     USES_TERMINAL
     COMMAND_EXPAND_LISTS
+    VERBATIM
     )
 
     add_custom_target(

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -340,14 +340,6 @@ function(_add_cargo_build)
             # override this by manually adding the appropriate rustflags to select the compiler for the target!
             set(cargo_target_linker "$<${if_not_host_build_condition}:${cargo_target_linker}>")
         endif()
-        # Will be only set for cross-compilers like clang, c.f. `CMAKE_<LANG>_COMPILER_TARGET`.
-        # Todo: is this block even necessary? I think rust/cargo already adds the flag.
-        if(CORROSION_LINKER_PREFERENCE_TARGET)
-            set(rustflag_linker_arg "-Clink-args=--target=${CORROSION_LINKER_PREFERENCE_TARGET}")
-            # Skip adding the linker argument, if the linker is explicitely set, since the
-            # explicit_linker_property will not be set when this function runs.
-            corrosion_add_target_rustflags("${target_name}" "$<$<NOT:${explicit_linker_property}>:${rustflag_linker_arg}>")
-        endif()
     else()
         message(DEBUG "No linker preference for target ${target_name} could be detected.")
         # Note: Adding quotes here introduces wierd errors when using MSVC. Since there are no spaces here at

--- a/test/rustflags/CMakeLists.txt
+++ b/test/rustflags/CMakeLists.txt
@@ -4,10 +4,10 @@ add_executable(rustflags-cpp-exe main.cpp)
 target_link_libraries(rustflags-cpp-exe PUBLIC rustflag-test-lib)
 
 # Test --cfg=key="value" rustflag.
-corrosion_add_target_rustflags(rustflag-test-lib "--cfg=test_rustflag_cfg1=\\\"test_rustflag_cfg1_value\\\"")
+corrosion_add_target_rustflags(rustflag-test-lib --cfg=test_rustflag_cfg1="test_rustflag_cfg1_value")
 
 # Test using a generator expression to produce a rustflag and passing multiple rustflags.
 corrosion_add_target_rustflags(rustflag-test-lib
-        "--cfg=test_rustflag_cfg2=\\\"$<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:>>,debug,release>\\\""
+        --cfg=test_rustflag_cfg2="$<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:>>,debug,release>"
         "--cfg=test_rustflag_cfg3"
 )


### PR DESCRIPTION
- Allow explicitily setting a linker for when linking is done via cargo.
- Use `VERBATIM` option when invoking `cargo build` so that CMake quotes as necessary. This should improve the experience for passing some parameters, but is a breaking change.

Closes #133 
Closes #88 
