### PR TITLE
Always set IMPORTED_LOCATION 

### DIFF
--- a/test/cpp2rust/lib2.cpp
+++ b/test/cpp2rust/lib2.cpp
@@ -1,6 +1,11 @@
 #include <iostream>
+#include <stdint.h>
 
 extern "C" void cpp_function2(char const *name) {
     std::cout << "Hello, " << name << "! I'm C++ library Number 2!\n";
 }
 
+extern "C" uint32_t get_42() {
+    uint32_t v = 42;
+    return v;
+}

--- a/test/cpp2rust/rust/Cargo.lock
+++ b/test/cpp2rust/rust/Cargo.lock
@@ -3,5 +3,12 @@
 version = 3
 
 [[package]]
+name = "rust-dependency"
+version = "0.1.0"
+
+[[package]]
 name = "rust-exe"
 version = "0.1.0"
+dependencies = [
+ "rust-dependency",
+]

--- a/test/cpp2rust/rust/Cargo.toml
+++ b/test/cpp2rust/rust/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-
+rust-dependency = { path = "rust_dependency"}

--- a/test/cpp2rust/rust/rust_dependency/Cargo.toml
+++ b/test/cpp2rust/rust/rust_dependency/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust-dependency"
+version = "0.1.0"
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+

--- a/test/cpp2rust/rust/rust_dependency/src/lib.rs
+++ b/test/cpp2rust/rust/rust_dependency/src/lib.rs
@@ -1,0 +1,8 @@
+
+extern "C" {
+    fn get_42() -> u32;
+}
+pub fn calls_ffi() {
+    let res = unsafe { get_42()};
+    assert_eq!(res, 42);
+}

--- a/test/cpp2rust/rust/src/main.rs
+++ b/test/cpp2rust/rust/src/main.rs
@@ -23,4 +23,5 @@ fn main() {
     } else {
         greeting("Rust");
     }
+    rust_dependency::calls_ffi();
 }


### PR DESCRIPTION
Not setting `IMPORTED_LOCATION` on imported executables causes CMake
developer warnings. Setting `IMPORTED_LOCATION_<CONFIG>` is _not_ sufficient.
The issue only affects Multi-Config Generators like Ninja-MultiConfig or
Visual Studio, since otherwise `IMPORTED_LOCATION` is already always set.

For Multi-Config builds there is no "correct" thing to set
`IMPORTED_LOCATION` to, so we just always set it, and the last configuration
wins. This is not a problem since the more specific `IMPORTED_LOCATION_<CONFIG>`
variants are also set in the multi-config case.

