### PR TITLE
Revert: Remove --target linker arg

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -340,6 +340,14 @@ function(_add_cargo_build)
             # override this by manually adding the appropriate rustflags to select the compiler for the target!
             set(cargo_target_linker "$<${if_not_host_build_condition}:${cargo_target_linker}>")
         endif()
+        # Will be only set for cross-compilers like clang, c.f. `CMAKE_<LANG>_COMPILER_TARGET`.
+        if(CORROSION_LINKER_PREFERENCE_TARGET)
+            set(rustflag_linker_arg "-Clink-args=--target=${CORROSION_LINKER_PREFERENCE_TARGET}")
+            # Skip adding the linker argument, if the linker is explicitly set, since the
+            # explicit_linker_property will not be set when this function runs.
+            # Passing this rustflag is necessary for clang.
+            corrosion_add_target_rustflags("${target_name}" "$<$<NOT:$<BOOL:${explicit_linker_property}>>:${rustflag_linker_arg}>")
+        endif()
     else()
         message(DEBUG "No linker preference for target ${target_name} could be detected.")
         # Note: Adding quotes here introduces wierd errors when using MSVC. Since there are no spaces here at


### PR DESCRIPTION
Revert commit cb4e49e240d5c4d58b6117b426264121d8e1deac. When cross-compiling with clang it is necessary to manually add this flag. It appears that Rust does not add the flag for us. CI currently does not test clang + cross-compiling and it's not trivial to add without doubling the number of tests or reworking the github actions. Regression testing will be added in a future commit.