### PR TITLE
Support "local" rustflags only affecting the main crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ Some configuration options can be specified individually for each target. You ca
   the `RUSTFLAGS` environment variable will contain the flags added via this function. Please note that any
   dependencies (built by cargo) will also see these flags. In the future corrosion may offer a second function
   to allow specifying flags only for the target in question, utilizing `cargo rustc` instead of `cargo build`.
+- `corrosion_add_target_local_rustflags(target_name rustc_flag [more_flags ...])`: Support setting
+  rustflags for only the main target (crate ) and none of it's dependencies.
+  This is useful in cases where you only need rustflags on the main-crate, but need to set different
+  flags for different targets. Without "local" Rustflags this would require rebuilds of the
+  dependencies when switching targets.
 - `corrosion_set_hostbuild(<target_name>)`: The target should be compiled for the Host target and ignore any
   cross-compile configuration.
 - `corrosion_set_features(<target_name> [ALL_FEATURES <Bool>] [NO_DEFAULT_FEATURES] [FEATURES <feature1> ... ])`:
@@ -229,6 +234,12 @@ Some configuration options can be specified individually for each target. You ca
 - `corrosion_set_flags(<target_name> <flag1> ...])`:
   For a given target, add options and flags at the end of `cargo build` invocation. This will be appended after any
   arguments passed through the `FLAGS` during the crate import.
+- `corrosion_set_linker(target_name linker)`: Use `linker` to link the target.
+  Please note that this only has an effect for targets where the final linker invocation is done
+  by cargo, i.e. targets where foreign code is linked into rust code and not the other way around.
+  Please also note that if you are cross-compiling and specify a linker such as `clang`, you are
+  responsible for also adding a rustflag which adds the necessary `--target=` argument for the
+  linker.
 
 ### Selecting a custom cargo profile
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,21 +1,41 @@
 # Unreleased
 
-# Breaking
+## Breaking
 
 - The minimum supported rust version was increased to 1.46, due to a cargo issue that recently
   surfaced on CI when using crates.io.
+- Increase the minimum required CMake version to 3.15 (may be bumped to 3.16 before the next release).
 
-# Potentially breaking
+## Potentially breaking
 
 - The working directory when invoking `cargo build` was changed to the directory of the Manifest
   file. This now allows cargo to pick up `.cargo/config.toml` files located in the source tree.
+  ([205](https://github.com/corrosion-rs/corrosion/pull/205))
 - Corrosion internally invokes `cargo build`. When passing arguments to `cargo build`, Corrosion
   now uses the CMake `VERBATIM` option. In rare cases this may require you to change how you quote
   parameters passed to corrosion (e.g. via `corrosion_add_target_rustflags()`).
   For example setting a `cfg` option previously required double escaping the rustflag like this
   `"--cfg=something=\\\"value\\\""`, but now it can be passed to corrosion without any escapes:
   `--cfg=something="value"`.
-  
+
+## New features
+
+- Support setting rustflags for only the main target and none of it's dependencies ([215](https://github.com/corrosion-rs/corrosion/pull/215)).
+  A new function `corrosion_add_target_local_rustflags(target_name rustc_flag [more_flags ...])`
+  is added for this purpose.
+  This is useful in cases where you only need rustflags on the main-crate, but need to set different
+  flags for different targets. Without "local" Rustflags this would require rebuilds of the
+  dependencies when switching targets.
+- Support explicitly selecting a linker ([208](https://github.com/corrosion-rs/corrosion/pull/208)).
+  The linker can be selected via `corrosion_set_linker(target_name linker)`.
+  Please note that this only has an effect for targets, where the final linker invocation is done
+  by cargo, i.e. targets where foreign code is linked into rust code and not the other way around.
+
+## Fixes
+
+- Fix a CMake developer Warning when a Multi-Config Generator and Rust executable targets
+  ([#213](https://github.com/corrosion-rs/corrosion/pull/213)).
+
 # 0.2.2 (2022-09-01)
 
 ## Fixes

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -252,10 +252,7 @@ function(_add_cargo_build)
         set(no_default_libraries_arg --no-default-libraries)
     endif()
 
-    set(rustflags_target_property "$<TARGET_GENEX_EVAL:${target_name},$<TARGET_PROPERTY:${target_name},INTERFACE_CORROSION_RUSTFLAGS>>")
-    # `rustflags_target_property` may contain multiple arguments and double quotes, so we _should_ single quote it to
-    # preserve any double quotes and keep it as one argument value. However single quotes don't work on windows, so we
-    # can only add double quotes here. Any double quotes _in_ the rustflags must be escaped like `\\\"`.
+    set(global_rustflags_target_property "$<TARGET_GENEX_EVAL:${target_name},$<TARGET_PROPERTY:${target_name},INTERFACE_CORROSION_RUSTFLAGS>>")
 
     set(features_target_property "$<GENEX_EVAL:$<TARGET_PROPERTY:${target_name},${_CORR_PROP_FEATURES}>>")
     set(features_genex "$<$<BOOL:${features_target_property}>:--features=$<JOIN:${features_target_property},$<COMMA>>>")
@@ -358,8 +355,8 @@ function(_add_cargo_build)
         corrosion_add_target_rustflags("${target_name}" "-Cdefault-linker-libraries=yes")
     endif()
 
-    set(joined_rustflags "$<JOIN:${rustflags_target_property}, >")
-    set(rustflags_genex "$<$<BOOL:${rustflags_target_property}>:RUSTFLAGS=${joined_rustflags}>")
+    set(global_joined_rustflags "$<JOIN:${global_rustflags_target_property}, >")
+    set(global_rustflags_genex "$<$<BOOL:${global_rustflags_target_property}>:RUSTFLAGS=${global_joined_rustflags}>")
 
     # Used to set a linker for a specific target-triple.
     set(cargo_target_linker_var "CARGO_TARGET_${_CORROSION_RUST_CARGO_TARGET_UPPER}_LINKER")
@@ -397,7 +394,7 @@ function(_add_cargo_build)
     COMMAND
         ${CMAKE_COMMAND} -E env
             "${build_env_variable_genex}"
-            "${rustflags_genex}"
+            "${global_rustflags_genex}"
             "${cargo_target_linker}"
             "${corrosion_cc_rs_flags}"
             "${cargo_library_path}"

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -347,13 +347,13 @@ function(_add_cargo_build)
         list(APPEND corrosion_cc_rs_flags "SDKROOT=${CMAKE_OSX_SYSROOT}")
     endif()
 
-    corrosion_add_target_rustflags("${target_name}" "$<$<BOOL:${corrosion_link_args}>:-Clink-args=${corrosion_link_args}>")
+    corrosion_add_target_local_rustflags("${target_name}" "$<$<BOOL:${corrosion_link_args}>:-Clink-args=${corrosion_link_args}>")
 
     # todo: this should probably also be guarded by if_not_host_build_condition.
     if(COR_NO_STD)
-        corrosion_add_target_rustflags("${target_name}" "-Cdefault-linker-libraries=no")
+        corrosion_add_target_local_rustflags("${target_name}" "-Cdefault-linker-libraries=no")
     else()
-        corrosion_add_target_rustflags("${target_name}" "-Cdefault-linker-libraries=yes")
+        corrosion_add_target_local_rustflags("${target_name}" "-Cdefault-linker-libraries=yes")
     endif()
 
     set(global_joined_rustflags "$<JOIN:${global_rustflags_target_property}, >")
@@ -379,7 +379,7 @@ function(_add_cargo_build)
             # Skip adding the linker argument, if the linker is explicitly set, since the
             # explicit_linker_property will not be set when this function runs.
             # Passing this rustflag is necessary for clang.
-            corrosion_add_target_rustflags("${target_name}" "$<$<NOT:$<BOOL:${explicit_linker_property}>>:${rustflag_linker_arg}>")
+            corrosion_add_target_local_rustflags("${target_name}" "$<$<NOT:$<BOOL:${explicit_linker_property}>>:${rustflag_linker_arg}>")
         endif()
     else()
         message(DEBUG "No linker preference for target ${target_name} could be detected.")
@@ -704,8 +704,8 @@ function(corrosion_link_libraries target_name)
             $<TARGET_PROPERTY:${library},LINKER_LANGUAGE>
         )
 
-        corrosion_add_target_rustflags(${target_name} "-L$<TARGET_LINKER_FILE_DIR:${library}>")
-        corrosion_add_target_rustflags(${target_name} "-l$<TARGET_LINKER_FILE_BASE_NAME:${library}>")
+        corrosion_add_target_local_rustflags(${target_name} "-L$<TARGET_LINKER_FILE_DIR:${library}>")
+        corrosion_add_target_local_rustflags(${target_name} "-l$<TARGET_LINKER_FILE_BASE_NAME:${library}>")
     endforeach()
 endfunction(corrosion_link_libraries)
 

--- a/test/custom_profiles/rust/Cargo.lock
+++ b/test/custom_profiles/rust/Cargo.lock
@@ -3,12 +3,5 @@
 version = 3
 
 [[package]]
-name = "rustflag-test-lib"
-version = "0.1.0"
-dependencies = [
- "some_dependency",
-]
-
-[[package]]
-name = "some_dependency"
+name = "custom-profiles-lib"
 version = "0.1.0"

--- a/test/rustflags/CMakeLists.txt
+++ b/test/rustflags/CMakeLists.txt
@@ -11,3 +11,6 @@ corrosion_add_target_rustflags(rustflag-test-lib
         --cfg=test_rustflag_cfg2="$<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:>>,debug,release>"
         "--cfg=test_rustflag_cfg3"
 )
+
+corrosion_add_target_local_rustflags(rustflag-test-lib "--cfg=test_local_rustflag1")
+corrosion_add_target_local_rustflags(rustflag-test-lib --cfg=test_local_rustflag2="value")

--- a/test/rustflags/rust/Cargo.toml
+++ b/test/rustflags/rust/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
+some_dependency = { path = "some_dependency" }
 
 [lib]
 crate-type=["staticlib"]

--- a/test/rustflags/rust/some_dependency/Cargo.toml
+++ b/test/rustflags/rust/some_dependency/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_dependency"
+version = "0.1.0"
+license = "MIT"
+edition = "2018"
+

--- a/test/rustflags/rust/some_dependency/src/lib.rs
+++ b/test/rustflags/rust/some_dependency/src/lib.rs
@@ -1,0 +1,10 @@
+//! Test that the local rustflags are only passed to the main crate and not to dependencies.
+#[cfg(test_local_rustflag1)]
+const _: [(); 1] = [(); 2];
+
+#[cfg(test_local_rustflag2 = "value")]
+const _: [(); 1] = [(); 2];
+
+pub fn some_function() -> u32 {
+    42
+}

--- a/test/rustflags/rust/src/lib.rs
+++ b/test/rustflags/rust/src/lib.rs
@@ -27,7 +27,14 @@ pub extern "C" fn rust_second_function(name: *const c_char) {
 pub extern "C" fn rust_third_function(name: *const c_char) {
     let name = unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() };
     println!("Hello, {}! I'm Rust again, third time the charm!", name);
+    assert_eq!(some_dependency::some_function(), 42);
 }
 
 #[cfg(not(test_rustflag_cfg3))]
+const _: [(); 1] = [(); 2];
+
+#[cfg(not(test_local_rustflag1))]
+const _: [(); 1] = [(); 2];
+
+#[cfg(not(test_local_rustflag2 = "value"))]
 const _: [(); 1] = [(); 2];


### PR DESCRIPTION
For some scenarios it is better to not set Rustflags for all crates
in the dependency graph and instead only set it for the top-level
crate.
For example https://github.com/rust-lang/cargo/issues/8716
can be avoided in some scenarios by setting the rustflags via
rustc, which allows for faster rebuilds in such cases.

Note:
Switching to "cargo rustc" is slightly problematic in cases where a package has multiple crates (e.g. lib and one or more bins), however Corrosion doesn't actually support those cases right now anyway.
A follow-up PR will add support for multiple targets per package. 