### PR TITLE
Multitarget test

### DIFF
--- a/test/multitarget/CMakeLists.txt
+++ b/test/multitarget/CMakeLists.txt
@@ -2,6 +2,7 @@ corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml)
 
 add_library(cpp-lib4 lib.cpp)
 target_compile_features(cpp-lib4 PRIVATE cxx_std_14)
+target_compile_options(cpp-lib4 PRIVATE -fPIE)
 corrosion_link_libraries(bin1 cpp-lib4)
 corrosion_link_libraries(bin2 cpp-lib4)
 corrosion_link_libraries(bin3 cpp-lib4)

--- a/test/rust2cpp/CMakeLists.txt
+++ b/test/rust2cpp/CMakeLists.txt
@@ -2,3 +2,7 @@ corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml)
 
 add_executable(cpp-exe main.cpp)
 target_link_libraries(cpp-exe PUBLIC rust-lib)
+
+add_executable(cpp-exe-shared main.cpp)
+target_link_libraries(cpp-exe-shared
+        PUBLIC rust-lib-shared)

--- a/test/rust2cpp/rust/Cargo.toml
+++ b/test/rust2cpp/rust/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 [dependencies]
 
 [lib]
-crate-type=["staticlib"]
+crate-type=["staticlib", "cdylib"]


### PR DESCRIPTION
- To match rusts default relocation model, the foreign library should be compiled with -fPIE.
- add shared library to rust2cpp test