### PR TITLE
Add test for Rustflags in .cargo/config.toml

### DIFF
--- a/test/rustflags/CMakeLists.txt
+++ b/test/rustflags/CMakeLists.txt
@@ -4,3 +4,4 @@ set_tests_properties("rustflags_run_rustflags-cpp-exe" PROPERTIES PASS_REGULAR_E
         "Hello, Cpp! I'm Rust!\r?\nHello, Cpp again! I'm Rust in (Debug|Release) mode again!\r?\nHello, Cpp again! I'm Rust again, third time the charm!\r?\n$"
         )
 
+corrosion_tests_add_test(cargo_config_rustflags "cargo_config_rustflags")

--- a/test/rustflags/cargo_config_rustflags/.cargo/config.toml
+++ b/test/rustflags/cargo_config_rustflags/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg=some_cargo_config_rustflag"]

--- a/test/rustflags/cargo_config_rustflags/CMakeLists.txt
+++ b/test/rustflags/cargo_config_rustflags/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_project VERSION 0.1.0)
+include(../../test_header.cmake)
+
+corrosion_import_crate(MANIFEST_PATH Cargo.toml)
+
+# Do not use `corrosion_add_target_rustflags()` here, since we want to test if the rustflag from `.cargo/config.toml`
+# is picked up.
+
+# Local rustflags should not interfere with `.cargo/config.toml`, so enable one.
+corrosion_add_target_local_rustflags(cargo_config_rustflags "--cfg=local_rustflag")

--- a/test/rustflags/cargo_config_rustflags/Cargo.toml
+++ b/test/rustflags/cargo_config_rustflags/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "cargo_config_rustflags"
+version = "0.1.0"
+edition = "2018"

--- a/test/rustflags/cargo_config_rustflags/src/main.rs
+++ b/test/rustflags/cargo_config_rustflags/src/main.rs
@@ -1,0 +1,16 @@
+
+#[cfg(some_cargo_config_rustflag)]
+fn print_line() {
+    println!("Rustflag is enabled");
+}
+
+// test that local rustflags don't override global rustflags set via `.cargo/config`
+#[cfg(local_rustflag)]
+fn test_local_rustflag() {
+    println!("local_rustflag was enabled");
+}
+
+fn main() {
+    print_line();
+    test_local_rustflag();
+}


### PR DESCRIPTION
Add a test which checks if cargo picks
up rustflags set in `.cargo/config.toml` ( if the user project does not specify any global rustflags (RUSTFLAGS environment variable).

Closes #230