### PR TITLE
Fix post build custom commands after OUTPUT_DIRECTORY support

### DIFF
--- a/test/gensource/gensource/CMakeLists.txt
+++ b/test/gensource/gensource/CMakeLists.txt
@@ -14,4 +14,4 @@ add_custom_target(after_generation DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/foo.
 add_custom_target(genexdebug COMMAND ${CMAKE_COMMAND} -E echo "Config DEBUG: $<TARGET_PROPERTY:srcgen,IMPORTED_LOCATION_DEBUG> Config Release: $<TARGET_PROPERTY:srcgen,IMPORTED_LOCATION_RELEASE> IMPORTED_LOCATION: $<TARGET_PROPERTY:srcgen,IMPORTED_LOCATION>")
 
 corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml)
-add_dependencies(cargo-build_generated after_generation)
+add_dependencies(cargo-prebuild_generated after_generation)

--- a/test/output directory/CMakeLists.txt
+++ b/test/output directory/CMakeLists.txt
@@ -117,3 +117,10 @@ if(WIN32)
         set_tests_properties("output_directory_bin_pdb" PROPERTIES FIXTURES_REQUIRED "output_directory_build")
     endif()
 endif()
+
+add_test(NAME postbuild_custom_command
+    COMMAND
+    "${CMAKE_COMMAND}"
+    -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/build/another_dir/moved_bin"
+    )

--- a/test/output directory/output directory/CMakeLists.txt
+++ b/test/output directory/output directory/CMakeLists.txt
@@ -17,3 +17,10 @@ set_target_properties(rust_lib
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_lib"
         PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_lib_pdb"
 )
+
+add_custom_command(TARGET cargo-build_rust_bin POST_BUILD
+    COMMAND
+    ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/another_dir"
+    COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_PROPERTY:rust_bin,LOCATION>" "${CMAKE_CURRENT_BINARY_DIR}/another_dir/moved_bin"
+    )


### PR DESCRIPTION
The recent support for OUTPUT_DIRECTORY broke custom commands using
`POST_BUILD` and accessing build artifacts.
Add a dummy custom target with the existing name which depends on the
custom target. This ensures that `POST_BUILD` steps (on the internal
target) are done before the user facing target.