### PR TITLE
Remove deprecated functions and update Release notes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,14 +38,10 @@ if (CORROSION_GENERATOR_EXECUTABLE)
     set(CORROSION_INSTALL_EXECUTABLE_DEFAULT OFF)
 # If corrosion is used as a subdirectory, the CMake version is recent enough and the option is not
 # explicitly disabled, then we do not need to build the Rust based parser and use the CMake based
-# parser instead. `CORROSION_EXPERIMENTAL_PARSER` is a deprecated inverted version of
-# `CORROSION_NATIVE_TOOLING` and will be removed in version 0.3
+# parser instead.
 elseif((NOT _CORROSION_TOP_LEVEL)
         AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.19.0
-        AND (((NOT DEFINED CORROSION_EXPERIMENTAL_PARSER)
-                OR CORROSION_EXPERIMENTAL_PARSER)
-               OR NOT CORROSION_NATIVE_TOOLING)
-
+        AND NOT CORROSION_NATIVE_TOOLING
         )
     set(CORROSION_INSTALL_EXECUTABLE_DEFAULT OFF)
 else()

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,13 @@
   surfaced on CI when using crates.io.
 - Increase the minimum required CMake version to 3.15 (may be bumped to 3.16 before the next release).
 
+### Breaking: Removed previously deprecated functionality
+- Removed `add_crate()` function. Use `corrosio_import_crate` instead.
+- Removed `cargo_link_libraries()` function. Use `corrosion_link_libraries()` instead.
+- Removed experimental CMake option `CORROSION_EXPERIMENTAL_PARSER`. This option was never included in an official
+  release and has been marked as deprecated on the master branch since May 22.
+  The corresponding stable option is `CORROSION_NATIVE_TOOLING` albeit with inverted semantics.
+
 ## Potentially breaking
 
 - The working directory when invoking `cargo build` was changed to the directory of the Manifest

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -21,26 +21,10 @@ set(CORROSION_RESPECT_OUTPUT_DIRECTORY_DESCRIPTION
     `RUNTIME_OUTPUT_DIRECTORY`. This requires CMake >= 3.19, otherwise this option is forced off."
 )
 
-set(CORROSION_NATIVE_TOOLING_DEFAULT OFF)
-# `CORROSION_EXPERIMENTAL_PARSER` was not part of a tagged release, but we still provide a
-# deprecation notice for users that directly use corrosion on the master branch and may have set
-# this option.
-if(DEFINED CORROSION_EXPERIMENTAL_PARSER)
-    message(DEPRECATION "The experimental option `CORROSION_EXPERIMENTAL_PARSER` is now deprecated."
-                " Please use `CORROSION_NATIVE_TOOLING` instead (with inverted semantics)."
-                " This warning will be removed in version 0.3 and the variable silently ignored."
-    )
-    if(CORROSION_EXPERIMENTAL_PARSER)
-        set(CORROSION_NATIVE_TOOLING_DEFAULT OFF)
-    else()
-        set(CORROSION_NATIVE_TOOLING_DEFAULT ON)
-    endif()
-endif()
-
 option(
     CORROSION_NATIVE_TOOLING
     "${CORROSION_NATIVE_TOOLING_DESCRIPTION}"
-    ${CORROSION_NATIVE_TOOLING_DEFAULT}
+    OFF
 )
 
 option(CORROSION_RESPECT_OUTPUT_DIRECTORY
@@ -1095,12 +1079,6 @@ function(corrosion_import_crate)
     endif()
 endfunction(corrosion_import_crate)
 
-function(add_crate path_to_toml)
-    message(DEPRECATION "add_crate is deprecated. Switch to corrosion_import_crate.")
-
-    corrosion_import_crate(MANIFEST_PATH ${path_to_toml})
-endfunction(add_crate)
-
 function(corrosion_set_linker_language target_name language)
     message(DEPRECATION "corrosion_set_linker_language is deprecated."
             "Please use corrosion_set_linker and set a specific linker.")
@@ -1211,12 +1189,6 @@ function(corrosion_set_features target_name)
         )
     endif()
 endfunction()
-
-function(cargo_link_libraries)
-    message(DEPRECATION "cargo_link_libraries is deprecated. Switch to corrosion_link_libraries.")
-
-    corrosion_link_libraries(${ARGN})
-endfunction(cargo_link_libraries)
 
 function(corrosion_link_libraries target_name)
     add_dependencies(_cargo-build_${target_name} ${ARGN})


### PR DESCRIPTION
Remove previously deprecated functions.
The deprecations have been announced for a long time,
so it should be safe to remove these functions.
Removal is documented in Release notes.