### PR TITLE
Various FindRust improvements

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,8 @@
   However this did not work as expected in all cases and sometimes the `HOST_CC` variable would be set
   to a cross-compiler for unknown reasons. For this reason `HOST_CC` and `HOST_CXX` are not set by
   corrosion anymore, but users can still set them manually if required via `corrosion_set_env_vars()`.
+- The `CARGO_RUST_FLAGS` family of cache variables were removed. Corrosion does not internally use them
+  anymore.
 
 ## Potentially breaking
 
@@ -60,11 +62,16 @@
 - Corrosion now supports packages with potentially multiple binaries (bins) and a library (lib) at the
   same time. The only requirement is that the names of all `bin`s and `lib`s in the whole project must be unique.
   Users can set the names in the `Cargo.toml` by adding `name = <unique_name>` in the `[[bin]]` and `[lib]` tables.
+- FindRust now has improved support for the `VERSION` option of `find_package` and will now attempt to find a matching
+  toolchain version. Previously it was only checked if the default toolchain matched to required version.
+- For rustup managed toolchains a CMake error is issued with a helpful message if the required target for
+  the selected toolchain is not installed.
 
 ## Fixes
 
 - Fix a CMake developer Warning when a Multi-Config Generator and Rust executable targets
   ([#213](https://github.com/corrosion-rs/corrosion/pull/213)).
+- FindRust now respects the `QUIET` option to `find_package()` in most cases.
 
 ## Deprecation notice
 

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -48,6 +48,29 @@ endif()
 
 find_package(Rust REQUIRED)
 
+if(Rust_TOOLCHAIN_IS_RUSTUP_MANAGED)
+    execute_process(COMMAND rustup target list --toolchain "${Rust_TOOLCHAIN}"
+            OUTPUT_VARIABLE AVAILABLE_TARGETS_RAW
+    )
+    string(REPLACE "\n" ";" AVAILABLE_TARGETS_RAW "${AVAILABLE_TARGETS_RAW}")
+    string(REPLACE " (installed)" "" "AVAILABLE_TARGETS" "${AVAILABLE_TARGETS_RAW}")
+    set(INSTALLED_TARGETS_RAW "${AVAILABLE_TARGETS_RAW}")
+    list(FILTER INSTALLED_TARGETS_RAW INCLUDE REGEX " \\(installed\\)")
+    string(REPLACE " (installed)" "" "INSTALLED_TARGETS" "${INSTALLED_TARGETS_RAW}")
+    list(TRANSFORM INSTALLED_TARGETS STRIP)
+    if("${Rust_CARGO_TARGET}" IN_LIST AVAILABLE_TARGETS)
+        message(DEBUG "Cargo target ${Rust_CARGO_TARGET} is an official target-triple")
+        message(DEBUG "Installed targets: ${INSTALLED_TARGETS}")
+        if(NOT ("${Rust_CARGO_TARGET}" IN_LIST INSTALLED_TARGETS))
+            message(FATAL_ERROR "Target ${Rust_CARGO_TARGET} is not installed for toolchain ${Rust_TOOLCHAIN}.\n"
+                    "Help: Run `rustup target add --toolchain ${Rust_TOOLCHAIN} ${Rust_CARGO_TARGET}` to install "
+                    "the missing target."
+            )
+        endif()
+    endif()
+
+endif()
+
 if (NOT TARGET Corrosion::Generator)
     message(STATUS "Using Corrosion as a subdirectory")
 endif()

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -340,16 +340,6 @@ else()
     endif()
 endif()
 
-set(CARGO_RUST_FLAGS "" CACHE STRING "Flags to pass to rustc")
-set(CARGO_RUST_FLAGS_DEBUG "" CACHE STRING
-    "Flags to pass to rustc in Debug Configuration")
-set(CARGO_RUST_FLAGS_RELEASE "" CACHE STRING
-    "Flags to pass to rustc in Release Configuration")
-set(CARGO_RUST_FLAGS_MINSIZEREL -C opt-level=z CACHE STRING
-    "Flags to pass to rustc in MinSizeRel Configuration")
-set(CARGO_RUST_FLAGS_RELWITHDEBINFO -g CACHE STRING
-    "Flags to pass to rustc in RelWithDebInfo Configuration")
-
 execute_process(
     COMMAND "${Rust_CARGO_CACHED}" --version --verbose
     OUTPUT_VARIABLE _CARGO_VERSION_RAW


### PR DESCRIPTION
- Respect `QUIET` option to `find_package()`
- Improve respecting of `REQUIRED` option of `find_package()`
- Try to find suitable Rust version to satisfy  `VERSION` requirement of `find_package()`.  Previously, the version check would fail if the default toolchain did not match the version requirement.
- Add diagnostic, reminding the user to install target support via rustup if the target is not installed for the selected toolchain.
- Remove unused `CARGO_RUST_FLAGS`. 

Closes #224 