### PR TITLE
Read OUTPUT_DIRECTORY properties from main library target

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -123,12 +123,21 @@ endfunction()
 # directory target property value at configure time. This function must be deferred to the end of
 # the configure stage, so we can be sure that the output directory is not modified afterwards.
 function(_corrosion_set_imported_location_deferred target_name base_property output_directory_property filename)
-    get_target_property(output_directory ${target_name} "${output_directory_property}")
+    # The output directory property is expected to be set on the exposed target (without postfix),
+    # but we need to set the imported location on the actual library target with postfix.
+    if("${target_name}" MATCHES "^([^-]+)-(static|shared)$")
+        set(output_dir_prop_target_name "${CMAKE_MATCH_1}")
+    else()
+        set(output_dir_prop_target_name "${target_name}")
+    endif()
+
+    get_target_property(output_directory "${output_dir_prop_target_name}" "${output_directory_property}")
+    message(DEBUG "Output directory property (target ${output_dir_prop_target_name}): ${output_directory_property} dir: ${output_directory}")
 
     if(CMAKE_CONFIGURATION_TYPES AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.20.0)
         foreach(config_type ${CMAKE_CONFIGURATION_TYPES})
             string(TOUPPER "${config_type}" config_type_upper)
-            get_target_property(output_dir_curr_config ${target_name}
+            get_target_property(output_dir_curr_config "${output_dir_prop_target_name}"
                 "${output_directory_property}_${config_type_upper}"
             )
             if(output_dir_curr_config)

--- a/test/output directory/CMakeLists.txt
+++ b/test/output directory/CMakeLists.txt
@@ -45,7 +45,7 @@ add_test(NAME output_directory_bin
         -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/build/custom_bin/${bin_name}"
 )
-set_tests_properties("output_directory_bin" PROPERTIES FIXTURES_REQUIRED "output_directory_build")
+set_tests_properties("output_directory_bin" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
 
 set(lib_name "rust_lib")
 
@@ -61,7 +61,7 @@ add_test(NAME output_directory_staticlib
         -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/build/custom_archive/${static_lib_name}"
 )
-set_tests_properties("output_directory_staticlib" PROPERTIES FIXTURES_REQUIRED "output_directory_build")
+set_tests_properties("output_directory_staticlib" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
 
 if(WIN32)
     set(dynamic_lib_name "${lib_name}.dll")
@@ -77,7 +77,7 @@ add_test(NAME output_directory_cdylib
         -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/build/custom_lib/${dynamic_lib_name}"
 )
-set_tests_properties("output_directory_cdylib" PROPERTIES FIXTURES_REQUIRED "output_directory_build")
+set_tests_properties("output_directory_cdylib" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
 
 if(WIN32)
     if(MSVC)
@@ -95,7 +95,7 @@ if(WIN32)
         # https://cmake.org/cmake/help/v3.25/manual/cmake-buildsystem.7.html#archive-output-artifacts
         "${CMAKE_CURRENT_BINARY_DIR}/build/custom_archive/${implib_name}"
         )
-    set_tests_properties("output_directory_implib" PROPERTIES FIXTURES_REQUIRED "output_directory_build")
+    set_tests_properties("output_directory_implib" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
 
     if(MSVC)
         set(lib_pdb_name "${lib_name}.pdb")
@@ -105,7 +105,7 @@ if(WIN32)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/build/custom_lib_pdb/${lib_pdb_name}"
             )
-        set_tests_properties("output_directory_cdylib_pdb" PROPERTIES FIXTURES_REQUIRED "output_directory_build")
+        set_tests_properties("output_directory_cdylib_pdb" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
 
         set(bin_pdb_name "rust_bin.pdb")
         add_test(NAME output_directory_bin_pdb
@@ -114,7 +114,7 @@ if(WIN32)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/build/custom_bin_pdb/${bin_pdb_name}"
             )
-        set_tests_properties("output_directory_bin_pdb" PROPERTIES FIXTURES_REQUIRED "output_directory_build")
+        set_tests_properties("output_directory_bin_pdb" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
     endif()
 endif()
 
@@ -124,3 +124,4 @@ add_test(NAME postbuild_custom_command
     -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/build/another_dir/moved_bin"
     )
+set_tests_properties("postbuild_custom_command" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")

--- a/test/output directory/output directory/CMakeLists.txt
+++ b/test/output directory/output directory/CMakeLists.txt
@@ -24,3 +24,8 @@ add_custom_command(TARGET cargo-build_rust_bin POST_BUILD
     COMMAND
     ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_PROPERTY:rust_bin,LOCATION>" "${CMAKE_CURRENT_BINARY_DIR}/another_dir/moved_bin"
     )
+
+add_executable(consumer consumer.cpp)
+add_dependencies(consumer cargo-build_rust_lib)
+
+target_link_libraries(consumer rust_lib)

--- a/test/output directory/output directory/consumer.cpp
+++ b/test/output directory/output directory/consumer.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <cstdlib>
+
+extern "C" unsigned int ret_12();
+
+
+int main(int argc, char *argv[])
+{
+    std::cout << "HI\n";
+    unsigned int a = ret_12();
+    if (a != 12) {
+        return -1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Previously, the properties were read from the wrong target. The IMPORTED_LOCATION property needs to be set on the internal target, but the OUTPUT_DIRECTORY properties set by the user will be set on the user facing target (without -static or -shared suffix).

Closes #240