### PR TITLE
add corrosion_add_target_generated_headers function for code generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ Some configuration options can be specified individually for each target. You ca
   the environment variable will only be set for direct builds of the target via cmake, and not for any
   build where cargo built the crate in question as a dependency for another target.
   The environment variables may contain generator expressions.
+- `corrosion_add_target_generated_headers(<target_name>)`: Use this for crates whose build scripts generate C/C++
+  headers to add the headers to the target's include paths. Currently cxx-build and cxx-qt-build support this.
+  The build script must output the generated headers to the path specified by the GENERATED_HEADER_DIR environment
+  variable for this to work.
 - `corrosion_add_target_rustflags(<target_name> <rustflag> [... <rustflagN>])`: When building the target,
   the `RUSTFLAGS` environment variable will contain the flags added via this function. Please note that any
   dependencies (built by cargo) will also see these flags. In the future corrosion may offer a second function

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1142,6 +1142,12 @@ function(corrosion_set_hostbuild target_name)
     )
 endfunction()
 
+function(corrosion_add_target_generated_headers target_name)
+    set(generated_header_dir "${CMAKE_CURRENT_BINARY_DIR}/generated-code")
+    target_include_directories("${target_name}" INTERFACE "${generated_header_dir}")
+    corrosion_set_env_vars("${target_name}" "GENERATED_HEADER_DIR=${generated_header_dir}")
+endfunction()
+
 # Add flags for rustc (RUSTFLAGS) which affect the target and all of it's Rust dependencies
 #
 # Additional rustflags may be passed as optional parameters after rustflag.


### PR DESCRIPTION
This sets the GENERATED_HEADER_DIR environment variable when calling cargo and adds that path to the target's include paths. Cargo build scripts can read this to determine where to output generated C/C++ headers.

Depends on https://github.com/dtolnay/cxx/pull/1120 for cxx-build

Fixes https://github.com/corrosion-rs/corrosion/issues/204