### PR TITLE
Fix windows abi detection

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -517,7 +517,7 @@ function(_corrosion_add_library_target workspace_manifest_path target_name has_s
         set(dynamic_lib_name "lib${lib_name}.so")
     endif()
 
-    if(MSVC)
+    if(is_windows_msvc)
         set(implib_name "${lib_name}.dll.lib")
     elseif(is_windows_gnu)
         set(implib_name "lib${lib_name}.dll.a")


### PR DESCRIPTION
It turns out that the CMake `MSVC` option is not interchangable with the abi property, since non-MSVC compilers can (attempt to) produce msvc compatible ABI.
Therefor revert to a checking the rust abi property.