### PR TITLE
Don't set linker for MSVC abi

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -729,7 +729,7 @@ endif()
 # A target may be either a specific bin
 function(_add_cargo_build out_cargo_build_out_dir)
     set(options "")
-    set(one_value_args PACKAGE TARGET MANIFEST_PATH PROFILE TARGET_KIND)
+    set(one_value_args PACKAGE TARGET MANIFEST_PATH PROFILE TARGET_KIND WORKSPACE_MANIFEST_PATH)
     set(multi_value_args BYPRODUCTS)
     cmake_parse_arguments(
         ACB
@@ -744,6 +744,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
     set(path_to_toml "${ACB_MANIFEST_PATH}")
     set(cargo_profile_name "${ACB_PROFILE}")
     set(target_kind "${ACB_TARGET_KIND}")
+    set(workspace_manifest_path "${ACB_WORKSPACE_MANIFEST_PATH}")
 
     if(NOT target_kind)
         message(FATAL_ERROR "TARGET_KIND not specified")
@@ -768,9 +769,12 @@ function(_add_cargo_build out_cargo_build_out_dir)
         set (build_dir .)
     endif()
 
+    unset(is_windows_msvc)
+    get_source_file_property(is_windows_msvc "${workspace_manifest_path}" CORROSION_PLATFORM_IS_WINDOWS_MSVC)
+
     # For MSVC targets, don't mess with linker preferences.
     # TODO: We still should probably make sure that rustc is using the correct cl.exe to link programs.
-    if (NOT MSVC)
+    if (NOT is_windows_msvc)
         set(languages C CXX Fortran)
 
         set(has_compiler OFF)

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -94,6 +94,7 @@ function(_generator_add_package_targets workspace_manifest_path package_manifest
                 PACKAGE ${package_name}
                 TARGET ${target_name}
                 MANIFEST_PATH "${manifest_path}"
+                WORKSPACE_MANIFEST_PATH "${workspace_manifest_path}"
                 PROFILE "${profile}"
                 TARGET_KIND "lib"
                 BYPRODUCTS "${byproducts}"
@@ -130,6 +131,7 @@ function(_generator_add_package_targets workspace_manifest_path package_manifest
                 PACKAGE "${package_name}"
                 TARGET "${target_name}"
                 MANIFEST_PATH "${manifest_path}"
+                WORKSPACE_MANIFEST_PATH "${workspace_manifest_path}"
                 PROFILE "${profile}"
                 TARGET_KIND "bin"
                 BYPRODUCTS "${byproducts}"

--- a/generator/src/subcommands/gen_cmake.rs
+++ b/generator/src/subcommands/gen_cmake.rs
@@ -59,7 +59,6 @@ pub fn invoke(
     args: &crate::GeneratorSharedArgs,
     matches: &ArgMatches,
 ) -> Result<(), Box<dyn std::error::Error>> {
-
     let mut out_file: Box<dyn Write> = if let Some(path) = matches.value_of(OUT_FILE) {
         let path = Path::new(path);
         if let Some(parent) = path.parent() {
@@ -95,11 +94,9 @@ cmake_minimum_required(VERSION 3.15)
         .flat_map(|package| {
             let package2 = package.clone();
             let ws_manifest_path = workspace_manifest_path.clone();
-            package
-                .targets
-                .clone()
-                .into_iter()
-                .filter_map(move |t| target::CargoTarget::from_metadata(package2.clone(), t, ws_manifest_path.clone()))
+            package.targets.clone().into_iter().filter_map(move |t| {
+                target::CargoTarget::from_metadata(package2.clone(), t, ws_manifest_path.clone())
+            })
         })
         .collect();
 
@@ -107,10 +104,7 @@ cmake_minimum_required(VERSION 3.15)
 
     for target in &targets {
         target
-            .emit_cmake_target(
-                &mut out_file,
-                cargo_profile,
-            )
+            .emit_cmake_target(&mut out_file, cargo_profile)
             .unwrap();
     }
 


### PR DESCRIPTION
MSVC abi may be used independently of the MSVC generator. MSVC uses cl.exe, so we can't use
the compiler as the linker driver.
We continue to just ignore MSVC in this case and let cargo / rust decide on the linker on its own.