### PR TITLE
Fix Multi-Config Generator default output directory

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -147,7 +147,7 @@ function(_corrosion_set_imported_location_deferred target_name base_property out
         elseif(output_directory)
             set(curr_out_dir "${output_directory}")
         else()
-            set(curr_out_dir "${CMAKE_CURRENT_BINARY_DIR}/${config_type}")
+            set(curr_out_dir "${CMAKE_CURRENT_BINARY_DIR}")
         endif()
         message(DEBUG "Setting ${base_property}_${config_type_upper} for target ${target_name}"
                 " to `${curr_out_dir}/${filename}`.")
@@ -265,11 +265,12 @@ function(_corrosion_copy_byproduct_deferred target_name output_dir_prop_name car
             # Fallback to `output_dir` if specified
             # Note: Multi-configuration generators append a per-configuration subdirectory to the
             # specified directory unless a generator expression is used (from CMake documentation).
-            # todo: double check if cmake does this or if we have to do it here
             set(curr_out_dir "${output_dir}")
         else()
-            # Fallback to default directory.
-            set(curr_out_dir "${CMAKE_CURRENT_BINARY_DIR}/${config_type}")
+            # Fallback to the default directory. We do not append the configuration directory here
+            # and instead let CMake do this, since otherwise the resolving of dynamic library
+            # imported paths may fail.
+            set(curr_out_dir "${CMAKE_CURRENT_BINARY_DIR}")
         endif()
         set(multiconfig_out_dir_genex "${multiconfig_out_dir_genex}$<$<CONFIG:${config_type}>:${curr_out_dir}>")
     endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,9 @@ function(corrosion_tests_add_test test_name bin_names)
         # Mainly used in CI to build the native generator once and then reuse it for all tests
         set(TEST_GENERATOR_BIN EXTERNAL_CORROSION_GENERATOR "${CORROSION_GENERATOR_EXECUTABLE}")
     endif()
+    if(CMAKE_CROSSCOMPILING)
+        set(TEST_SYSTEM_NAME SYSTEM_NAME "${CMAKE_SYSTEM_NAME}")
+    endif()
 
     add_test(NAME "${test_name}_build"
             COMMAND
@@ -81,7 +84,7 @@ function(corrosion_tests_add_test test_name bin_names)
             GENERATOR "${CMAKE_GENERATOR}"
             RUST_TOOLCHAIN "${Rust_TOOLCHAIN}"
             CARGO_TARGET "${Rust_CARGO_TARGET}"
-            SYSTEM_NAME "${CMAKE_SYSTEM_NAME}"
+            "${TEST_SYSTEM_NAME}"
             "${TEST_C_COMPILER}"
             "${TEST_CXX_COMPILER}"
             "${TEST_GENERATOR_PLATFORM}"

--- a/test/ConfigureAndBuild.cmake
+++ b/test/ConfigureAndBuild.cmake
@@ -60,6 +60,7 @@ execute_process(
         "${CMAKE_COMMAND}"
             "-G${TEST_GENERATOR}"
             "-DRust_TOOLCHAIN=${TEST_RUST_TOOLCHAIN}"
+            --log-level Debug
             ${TEST_Rust_CARGO_TARGET}
             ${TEST_CORROSION_INSTALL}
             ${TEST_GENERATOR_PLATFORM}

--- a/test/workspace/workspace/CMakeLists.txt
+++ b/test/workspace/workspace/CMakeLists.txt
@@ -4,6 +4,6 @@ include(../../test_header.cmake)
 
 corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml CRATES member1 member2)
 
-#NOTE: member3 also constains a binary called my_program, but that shouldn't be a problem since it is not imported
+#NOTE: member3 also contains a binary called my_program, but that shouldn't be a problem since it is not imported
 add_executable(my_program main.cpp)
 target_link_libraries(my_program PUBLIC member1 member2)


### PR DESCRIPTION
Manually appending the configuration type may make
loading of shared libraries fail at runtime.
To prevent this, we let CMake postfix the Generator
configuration type.