### PR TITLE
CI: Add option to choose compiler

### DIFF
--- a/.github/actions/setup_test/action.yaml
+++ b/.github/actions/setup_test/action.yaml
@@ -27,6 +27,10 @@ inputs:
     required: false
     description: CMake install prefix
     default: ""
+  compiler:
+    required: false
+    description: Compiler to use. Valid options are clang, gcc and cl.
+    default: ""
 
 runs:
   using: composite
@@ -58,27 +62,30 @@ runs:
          else 
            echo "abi=msvc" >> $GITHUB_OUTPUT
          fi
+    - name: Determine if Cross-compiling
+      id: determine_cross_compile
+      shell: bash
+      run: |
+        # For now it is safe to assume that all github runners are x86_64
+        if [[ "${{ inputs.target_arch }}" != "x86_64" ]]; then
+          echo "Cross-Compiling to ${{ inputs.target_arch }}"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            echo "system_name=-DCMAKE_SYSTEM_NAME=Darwin" >> $GITHUB_OUTPUT
+          else
+            # Either `Linux` or `Windows`
+            echo "system_name=-DCMAKE_SYSTEM_NAME=${{ runner.os }}" >> $GITHUB_OUTPUT
+          fi
+        fi
     - name: Pick Compiler
       id: pick_compiler
       shell: bash
-      run: |
-        if [ "${{ steps.determine_abi.outputs.abi }}" == "gnu" ]; then
-          if [ "${{ runner.os }}" == "Linux" ]; then
-            echo "c_compiler=-DCMAKE_C_COMPILER=${{inputs.target_arch}}-linux-gnu-gcc" >> $GITHUB_OUTPUT
-            echo "cxx_compiler=-DCMAKE_CXX_COMPILER=${{inputs.target_arch}}-linux-gnu-g++" >> $GITHUB_OUTPUT
-            # todo: only set this when cross-compiling
-            echo "system_name=-DCMAKE_SYSTEM_NAME=Linux" >> $GITHUB_OUTPUT
-          else
-            echo "c_compiler=-DCMAKE_C_COMPILER=gcc" >> $GITHUB_OUTPUT
-            echo "cxx_compiler=-DCMAKE_CXX_COMPILER=g++" >> $GITHUB_OUTPUT
-          fi
-        elif [ "${{ steps.determine_abi.outputs.abi }}" == "darwin" ]; then
-          echo "c_compiler=-DCMAKE_C_COMPILER=clang" >> $GITHUB_OUTPUT
-          echo "cxx_compiler=-DCMAKE_CXX_COMPILER=clang++" >> $GITHUB_OUTPUT
-        elif [ "${{ steps.determine_abi.outputs.abi }}" == "msvc" ]; then
-          echo "c_compiler=-DCMAKE_C_COMPILER=cl" >> $GITHUB_OUTPUT
-          echo "cxx_compiler=-DCMAKE_CXX_COMPILER=cl" >> $GITHUB_OUTPUT
-        fi
+      run: > 
+        ./.github/scripts/determine_compiler.sh 
+        "${{ inputs.compiler }}"
+        "${{ runner.os }}"
+        "${{ steps.determine_abi.outputs.abi }}"
+        "${{steps.determine_cross_compile.outputs.system_name}}"
+        "${{inputs.target_arch}}"
     - name: Pick Generator
       id: pick_generator
       shell: bash
@@ -159,7 +166,7 @@ runs:
         "${{steps.arch_flags.outputs.cmake}}"
         "${{steps.pick_compiler.outputs.c_compiler}}"
         "${{steps.pick_compiler.outputs.cxx_compiler}}"
-        "${{steps.pick_compiler.outputs.system_name}}"
+        "${{steps.determine_cross_compile.outputs.system_name}}"
         "${{steps.pick_generator.outputs.generator}}"
         ${{steps.install_prefix.outputs.install_path}}
         "-DRust_TOOLCHAIN=${{inputs.rust}}"

--- a/.github/scripts/determine_compiler.sh
+++ b/.github/scripts/determine_compiler.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+compiler_kind="$1"
+runner_os="$2"
+target_abi="$3"
+target_system_name="$4"
+target_arch="$5"
+
+set -e
+
+if [[ -z "$GITHUB_OUTPUT" ]]; then
+  echo "Error: This script should only be run in github actions environment"
+  exit 1
+fi
+if [[ -z "${runner_os}" || -z "${target_abi}" || -z  "${target_arch}" ]]; then
+  echo "Error: Not all required parameters where set"
+  exit 1
+fi
+if [[ -z "${compiler_kind}" ]]; then
+  echo "compiler option was not set. Determining default compiler."
+  if [[ "${runner_os}" == "Windows" ]]; then
+    if [[ "${target_abi}" == "msvc" ]]; then
+      compiler_kind=msvc
+    elif [[ "${target_abi}" == "gnu" ]]; then
+      compiler_kind=gcc
+    else
+      echo "Unknown abi for Windows: ${target_abi}"
+      exit 1
+    fi
+  elif [[ "${runner_os}" == "macOS" ]]; then
+    compiler_kind="clang"
+  elif [[ "${runner_os}" == "Linux" ]]; then
+    compiler_kind="gcc"
+  else
+    echo "Unknown Runner OS: ${runner_os}"
+    exit 1
+  fi
+fi
+echo "Compiler Family: '${compiler_kind}'"
+
+if [[ "${compiler_kind}" == "clang" ]]; then
+  c_compiler="clang"
+  cxx_compiler="clang++"
+elif [[ "${compiler_kind}" == "msvc" ]]; then
+  c_compiler="cl"
+  cxx_compiler="cl"
+elif [[ "${compiler_kind}" == "gcc" ]]; then
+  if [[ -z "${target_system_name}" ]]; then
+    c_compiler="gcc"
+    cxx_compiler="g++"
+  else
+    c_compiler="${target_arch}-linux-gnu-gcc"
+    cxx_compiler="${target_arch}-linux-gnu-g++"
+  fi
+fi
+echo "Chose C compiler: '${c_compiler}'"
+echo "Chose C++ compiler: '${cxx_compiler}'"
+echo "c_compiler=-DCMAKE_C_COMPILER=${c_compiler}" >> $GITHUB_OUTPUT
+echo "cxx_compiler=-DCMAKE_CXX_COMPILER=${cxx_compiler}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
If the option is not given, we still choose a suitable default for the platform. If the option is given, then we set the compiler based on the input.

 This commit also fixes CMAKE_SYSTEM_NAME, which should now be always
 set manually when cross-compiling.