### PR TITLE
CI: Cache cargo registry

### DIFF
--- a/.github/actions/setup_test/action.yaml
+++ b/.github/actions/setup_test/action.yaml
@@ -35,6 +35,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Cache Cargo registry
+      id: cache-registry
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry
     - name: Determine Rust OS
       id: determine_rust_os
       shell: bash


### PR DESCRIPTION
Speed up CI by caching the .cargo registry.
This turns out to be _much_ faster than letting cargo update the cargo index/registry on first access.