### PR TITLE
CI: Cache MSVC build directory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -185,6 +185,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      # The initial configure for MSVC is quite slow, so we cache the build directory
+      # (including the build directories of the tests) since reconfiguring is
+      # significantly faster.
+      - name: Cache MSVC build directory
+        id: cache-msvc-builddir
+        uses: actions/cache@v3
+        with:
+          path: build
+          key: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.rust }}-msvc-build
       - name: Setup Environment and Configure CMake
         uses: "./.github/actions/setup_test"
         with:
@@ -194,6 +203,7 @@ jobs:
           rust: ${{matrix.rust}}
           generator: default
           build_dir: build
+          configure_params: "-DCORROSION_TESTS_KEEP_BUILDDIRS=ON"
       - name: Run Tests
         working-directory: build
         run: ctest --output-on-failure --build-config Debug -j 3

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,8 +6,13 @@ if(NOT CORROSION_TESTS)
 endif()
 
 option(CORROSION_TESTS_CXXBRIDGE
-        "Build cxxbridge tests which requires cxxbridge exectuable being available"
+        "Build cxxbridge tests which requires cxxbridge executable being available"
         OFF)
+option(CORROSION_TESTS_KEEP_BUILDDIRS
+    "By default corrosion tests will cleanup after themselves. This option limits the cleaning up to the
+     target directories and will keep the build directories, which may be useful for caching."
+    OFF)
+mark_as_advanced(CORROSION_TESTS_NO_CLEANUP)
 
 set(test_install_path "${CMAKE_CURRENT_BINARY_DIR}/test-install-corrosion")
 
@@ -123,8 +128,20 @@ function(corrosion_tests_add_test test_name bin_names)
             set_tests_properties("${test_name}_run_${bin}" PROPERTIES DISABLED TRUE)
         endif()
     endforeach()
-    add_test(NAME "${test_name}_cleanup" COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/build-${test_name}")
-    set_tests_properties("${test_name}_cleanup" PROPERTIES FIXTURES_CLEANUP "build_fixture_${test_name}")
+
+    if(CORROSION_TESTS_KEEP_BUILDDIRS)
+        add_test(NAME "${test_name}_cleanup_artifacts"
+            COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_CURRENT_BINARY_DIR}/build-${test_name}" --target clean
+        )
+        add_test(NAME "${test_name}_cleanup_cargo"
+            COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/build-${test_name}/cargo"
+            )
+        set_tests_properties("${test_name}_cleanup_artifacts" PROPERTIES FIXTURES_CLEANUP "build_fixture_${test_name}")
+        set_tests_properties("${test_name}_cleanup_cargo" PROPERTIES FIXTURES_CLEANUP "build_fixture_${test_name}")
+    else()
+        add_test(NAME "${test_name}_cleanup" COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/build-${test_name}")
+        set_tests_properties("${test_name}_cleanup" PROPERTIES FIXTURES_CLEANUP "build_fixture_${test_name}")
+    endif()
 endfunction()
 
 # Please keep this in alphabetical order.

--- a/test/custom_profiles/CMakeLists.txt
+++ b/test/custom_profiles/CMakeLists.txt
@@ -7,4 +7,9 @@ if(Rust_VERSION VERSION_LESS 1.57.0)
         set_tests_properties(custom_profiles_build custom_profiles_run_custom-profile-exe PROPERTIES
                 DISABLED TRUE
         )
+        if(TEST custom_profiles_cleanup_artifacts)
+                set_tests_properties(custom_profiles_cleanup_artifacts PROPERTIES
+                    DISABLED TRUE
+            )
+        endif()
 endif()


### PR DESCRIPTION
The initial configure for MSVC is quite slow, so we cache the build directory since reconfiguring is faster.