### PR TITLE
Add convenience function to parse package version from Cargo.toml

### DIFF
--- a/test/gensource/gensource/CMakeLists.txt
+++ b/test/gensource/gensource/CMakeLists.txt
@@ -15,3 +15,9 @@ add_custom_target(genexdebug COMMAND ${CMAKE_COMMAND} -E echo "Config DEBUG: $<T
 
 corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml)
 add_dependencies(cargo-prebuild_generated after_generation)
+
+# Simple test for corrosion_parse_package_version
+corrosion_parse_package_version("${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml" srcgen_version)
+if (NOT "${srcgen_version}" VERSION_EQUAL "0.1.0")
+	message(FATAL_ERROR "Test failed to parse expected version")
+endif()


### PR DESCRIPTION
Add a convenience function to parse the package version from the package manifest (Cargo.toml). This is mainly intended for code generators written in Rust, so that downstream users can easily check if an installed version of the code generator is up to date with the version specified in the package manifest. Users could then decide to rebuild from source if the installed version is outdated and otherwise use the installed version.