### PR TITLE
Remove `enable_language()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,9 @@ option(
 mark_as_advanced(CORROSION_INSTALL_EXECUTABLE)
 
 if (_CORROSION_TOP_LEVEL)
-    # TODO: If we don't have a language enabled, corrosion_import_crate will
-    # attempt to enable a C compiler. Ideally, we could delay this somehow until
-    # after we've set link libraries.
-    enable_language(CXX)
+    # We need to enable a language for corrosions test to work.
+    # For projects using corrosion this is not needed
+    enable_language(C)
 endif()
 
 # This little bit self-hosts the Corrosion toolchain to build the generator

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,35 @@
+# Unreleased
+
+## Breaking Changes
+
+- The Visual Studio Generators now require at least CMake 3.20.
+  This was previously announced in the 0.3.0 release notes.
+- The previously deprecated function `corrosion_set_linker_language()`
+  will now raise an error when called and may be removed without further
+  notice in future stable releases. Use `corrosion_set_linker()` instead.
+- Improved the FindRust target triple detection, which may cause different behavior in some cases.
+  The detection does not require an enabled language anymore and will always fall back
+  to the default host target triple. A warning is issued if target triple detection failed.
+
+
+## Other changes
+
+- When installing Corrosion with CMake >= 3.19, the legacy Generator tool is
+  no longer built and installed by default.
+- Corrosion now issues a warning when setting the linker or setting linker
+  options for a Rust static library.
+- Corrosion no longer enables the `C` language when CMake is in crosscompiling mode and
+  no languages where previously enabled. This is not considered a breaking change.
+
+## Fixes
+
+- Fix building when the `dev` profile is explicitly set by the user.
+
+## Experimental status (may be changed or removed before a stable release)
+- Get metadata with `--locked` (requires a lock-file). This might cause issues, reports are welcome.
+- Experimental cxxbridge integration.
+- Add a helper function to parse the package version from a Cargo.toml file
+
 # 0.3.2 (2023-01-11)
 
 ## New features (Only available on CMake >= 3.19)

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -766,12 +766,6 @@ function(_add_cargo_build out_cargo_build_out_dir)
             endif()
         endforeach()
 
-        # When cross-compiling a Rust crate, at the very least we need a C linker
-        if (NOT has_compiler AND CMAKE_CROSSCOMPILING)
-            message(STATUS "Enabling the C compiler for linking Rust programs")
-            enable_language(C)
-        endif()
-
         # Determine the linker CMake prefers based on the enabled languages.
         set(_CORROSION_LINKER_PREFERENCE_SCORE "0")
         foreach(language ${languages})


### PR DESCRIPTION
Corrosion itself does not need to enable any languages. If linking is done via Rust, then rust will by default use a target specific linker e.g. cc or rust-lld.
If C++ is used then this is not sufficient, but then the user will also have turned on C++ as a language of their project.

If linking is handled by CMake, then it is also the responsibility of the user to enable a language,
otherwise they couldn't compile any code anyway.