### PR TITLE
Remove linker preference code

### DIFF
--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -31,7 +31,7 @@ function(_cargo_metadata out manifest)
 endfunction()
 
 # Add targets (crates) of one package
-function(_generator_add_package_targets workspace_manifest_path package_manifest_path package_name targets profile no_linker_override out_created_targets crate_types)
+function(_generator_add_package_targets workspace_manifest_path package_manifest_path package_name targets profile out_created_targets crate_types)
     # target types
     set(has_staticlib FALSE)
     set(has_cdylib FALSE)
@@ -47,12 +47,6 @@ function(_generator_add_package_targets workspace_manifest_path package_manifest
 
     string(JSON targets_len LENGTH "${targets}")
     math(EXPR targets_len-1 "${targets_len} - 1")
-
-    if(${no_linker_override})
-        set(_NO_LINKER_OVERRIDE "NO_LINKER_OVERRIDE")
-    else()
-        set(_NO_LINKER_OVERRIDE "")
-    endif()
 
     foreach(ix RANGE ${targets_len-1})
         #
@@ -107,7 +101,6 @@ function(_generator_add_package_targets workspace_manifest_path package_manifest
             set(cargo_build_out_dir "")
             _add_cargo_build(
                 cargo_build_out_dir
-                ${_NO_LINKER_OVERRIDE}
                 PACKAGE ${package_name}
                 TARGET ${target_name}
                 MANIFEST_PATH "${manifest_path}"
@@ -145,7 +138,6 @@ function(_generator_add_package_targets workspace_manifest_path package_manifest
             set(cargo_build_out_dir "")
             _add_cargo_build(
                 cargo_build_out_dir
-                ${_NO_LINKER_OVERRIDE}
                 PACKAGE "${package_name}"
                 TARGET "${target_name}"
                 MANIFEST_PATH "${manifest_path}"
@@ -178,7 +170,7 @@ function(_generator_add_package_targets workspace_manifest_path package_manifest
 endfunction()
 
 
-function(_generator_add_cargo_targets no_linker_override)
+function(_generator_add_cargo_targets)
     set(options "")
     set(one_value_args MANIFEST_PATH PROFILE)
     set(multi_value_args CRATES CRATE_TYPES)
@@ -215,7 +207,7 @@ function(_generator_add_cargo_targets no_linker_override)
             if(ws_mem STREQUAL pkg_id AND ((NOT GGC_CRATES) OR (pkg_name IN_LIST GGC_CRATES)))
                 message(DEBUG "Found ${targets_len} targets in package ${pkg_name}")
 
-                _generator_add_package_targets("${GGC_MANIFEST_PATH}" "${pkg_manifest_path}" "${pkg_name}" "${targets}" "${GGC_PROFILE}" "${no_linker_override}" curr_created_targets "${GGC_CRATE_TYPES}")
+                _generator_add_package_targets("${GGC_MANIFEST_PATH}" "${pkg_manifest_path}" "${pkg_name}" "${targets}" "${GGC_PROFILE}" curr_created_targets "${GGC_CRATE_TYPES}")
                 list(APPEND created_targets "${curr_created_targets}")
             endif()
         endforeach()


### PR DESCRIPTION
Previously, corrosion set the linker to the C++ compiler in order to automatically link in the necessary libraries for C++ code. In practice this seems to be just "c++", so it seems we can also just use the default linker and let Corrosion specify "-lc++" as a linker argument for rust in case the target links in any C++ code.

This is generally preferable and should be more in line with users expect.

This change could potentially have some subtle pitfalls, so someone more familiar with C++ should review it.