### PR TITLE
Add parameter to corrosion_import_crate to return list of added targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ corrosion_import_crate(MANIFEST_PATH <path/to/cargo.toml>
         [NO_LINKER_OVERRIDE]
         # Will let Rust/Cargo determine which linker to use instead of corrosion (when linking is invoked by Rust) (Ignored with CMake < 3.19)
         [PROFILE <cargo-profile>]
+        # Retrieve the list of imported crates in the current scope
+        [IMPORTED_CRATES <variable-name>]
         # Build only the specified crate types (Ignored with CMake < 3.19)
         [CRATE_TYPES <crate_type1> ... <crate_typeN>]
         # Only import the specified crates from a workspace

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -29,7 +29,7 @@
 - Get metadata with `--locked` (requires a lock-file). This might cause issues, reports are welcome.
 - Experimental cxxbridge integration.
 - Add a helper function to parse the package version from a Cargo.toml file
-- Add new `IMPORTED_CRATES` flag to `corrosion_import_crate()` to retrieve the list of imported crates in the current scope ([#218](https://github.com/corrosion-rs/corrosion/pull/218)).
+- Add new `IMPORTED_CRATES` flag to `corrosion_import_crate()` to retrieve the list of imported crates in the current scope ([#312](https://github.com/corrosion-rs/corrosion/pull/312)).
 
 # 0.3.2 (2023-01-11)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -29,6 +29,7 @@
 - Get metadata with `--locked` (requires a lock-file). This might cause issues, reports are welcome.
 - Experimental cxxbridge integration.
 - Add a helper function to parse the package version from a Cargo.toml file
+- Add new `IMPORTED_CRATES` flag to `corrosion_import_crate()` to retrieve the list of imported crates in the current scope ([#218](https://github.com/corrosion-rs/corrosion/pull/218)).
 
 # 0.3.2 (2023-01-11)
 

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1038,7 +1038,7 @@ endfunction()
 
 function(corrosion_import_crate)
     set(OPTIONS ALL_FEATURES NO_DEFAULT_FEATURES NO_STD NO_LINKER_OVERRIDE)
-    set(ONE_VALUE_KEYWORDS MANIFEST_PATH PROFILE)
+    set(ONE_VALUE_KEYWORDS MANIFEST_PATH PROFILE IMPORTED_CRATES)
     set(MULTI_VALUE_KEYWORDS CRATE_TYPES CRATES FEATURES FLAGS)
     cmake_parse_arguments(COR "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}" ${ARGN})
 
@@ -1122,6 +1122,10 @@ function(corrosion_import_crate)
             PROFILE
                 "${COR_PROFILE}"
         )
+
+        if (DEFINED COR_IMPORTED_CRATES)
+            set(${COR_IMPORTED_CRATES} ${imported_crates} PARENT_SCOPE)
+        endif()
     endif()
 endfunction(corrosion_import_crate)
 

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -227,6 +227,8 @@ function(_generator_add_cargo_targets no_linker_override)
         message(DEBUG "Corrosion created the following CMake targets: ${curr_created_targets}")
     endif()
 
+    set(imported_crates ${created_targets} PARENT_SCOPE)
+
     foreach(target_name ${created_targets})
         foreach(output_var RUNTIME_OUTPUT_DIRECTORY ARCHIVE_OUTPUT_DIRECTORY LIBRARY_OUTPUT_DIRECTORY PDB_OUTPUT_DIRECTORY)
             get_target_property(output_dir ${target_name} "${output_var}")


### PR DESCRIPTION
This PR adds new `IMPORTED_CRATES` flag to `corrosion_import_crate()` to retrieve the list of imported crates in the current scope. Idea was from issue #218.

With this PR, this kind of operation is made possible.
```cmake
# Part of CMAKE file
corrosion_import_crate(MANIFEST_PATH ../native/Cargo.toml IMPORTED_CRATES crates_list)
target_link_libraries(${BINARY_NAME} PRIVATE ${crates_list})
```

I checked that this works as intended in an actual Rust/C++ project.
