### PR TITLE
Output Error if IMPORTED_CRATES is selected with CORROSION_NATIVE_TOOLING

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1067,6 +1067,11 @@ function(corrosion_import_crate)
     _corrosion_parse_platform(${COR_MANIFEST_PATH} ${Rust_VERSION} ${_CORROSION_RUST_CARGO_TARGET})
 
     if (CORROSION_NATIVE_TOOLING)
+        if(COR_IMPORTED_CRATES)
+            message(FATAL_ERROR "corrosion_import_crate option `IMPORTED_CRATES` may not be selected when "
+                "CORROSION_NATIVE_TOOLING is ON."
+            )
+        endif()
         execute_process(
             COMMAND
                 ${_CORROSION_GENERATOR}
@@ -1125,6 +1130,8 @@ function(corrosion_import_crate)
                 "${COR_CRATE_TYPES}"
             PROFILE
                 "${COR_PROFILE}"
+            IMPORTED_CRATES
+                imported_crates
         )
 
         if (DEFINED COR_IMPORTED_CRATES)

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -180,7 +180,7 @@ endfunction()
 
 function(_generator_add_cargo_targets no_linker_override)
     set(options "")
-    set(one_value_args MANIFEST_PATH PROFILE)
+    set(one_value_args MANIFEST_PATH PROFILE IMPORTED_CRATES)
     set(multi_value_args CRATES CRATE_TYPES)
     cmake_parse_arguments(
         GGC
@@ -227,7 +227,9 @@ function(_generator_add_cargo_targets no_linker_override)
         message(DEBUG "Corrosion created the following CMake targets: ${curr_created_targets}")
     endif()
 
-    set(imported_crates ${created_targets} PARENT_SCOPE)
+    if(GGC_IMPORTED_CRATES)
+        set(${GGC_IMPORTED_CRATES} "${created_targets}" PARENT_SCOPE)
+    endif()
 
     foreach(target_name ${created_targets})
         foreach(output_var RUNTIME_OUTPUT_DIRECTORY ARCHIVE_OUTPUT_DIRECTORY LIBRARY_OUTPUT_DIRECTORY PDB_OUTPUT_DIRECTORY)


### PR DESCRIPTION
Follow-up PR to #312.
Currently, the option is not supported with the old generator. It could be backported if someone needs it, but this isn't a priority.
Also properly pass through intermediate parameter names to pass back the list up the callchain.