### PR TITLE
CI: Use stable-2 toolchain for cxxbridge

### DIFF
--- a/.github/actions/setup_test/action.yaml
+++ b/.github/actions/setup_test/action.yaml
@@ -143,6 +143,7 @@ runs:
         cmake: ${{inputs.cmake}}
         ninja: 1.10.0
     - name: Install Rust
+      id: install_rust
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{inputs.rust}}
@@ -179,5 +180,5 @@ runs:
         "${{steps.determine_cross_compile.outputs.system_name}}"
         "${{steps.pick_generator.outputs.generator}}"
         ${{steps.install_prefix.outputs.install_path}}
-        "-DRust_TOOLCHAIN=${{inputs.rust}}"
+        "-DRust_TOOLCHAIN=${{steps.install_rust.outputs.name}}"
         ${{ inputs.configure_params }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -230,7 +230,7 @@ jobs:
         with:
           target_arch: x86_64
           cmake: 3.15.7
-          rust: 1.64.0
+          rust: stable minus 2 releases
           abi: ${{ matrix.abi }}
           generator: ninja
           build_dir: build


### PR DESCRIPTION
cxxbridge-cmd internally uses clap and liberally increases its MSRV so, we just test stable-2 in CI.