### PR TITLE
CI: Reduce cxxbridge job runtime

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -237,7 +237,7 @@ jobs:
           configure_params: -DCORROSION_TESTS_CXXBRIDGE=ON
       - name: Run Tests
         working-directory: build
-        run: ctest --output-on-failure --build-config Debug -j 3
+        run: ctest --output-on-failure --build-config Debug -j 3 -R "^cxxbridge"
   install:
     name: Test Corrosion as a Library
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Only run the cxxbridge tests in this job.
We test it seperately, since cxxbridge has a higher overhead than the other jobs, due to the necessary caching / installation of the cxxbridge-cmd tool.

In the future all bindings tests could be in this matrix.