### PR TITLE
Pass --no-deps to cargo metadata

### DIFF
--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -21,6 +21,8 @@ function(_cargo_metadata out manifest)
                     metadata
                         --manifest-path "${manifest}"
                         --format-version 1
+                        # We don't care about non-workspace dependencies
+                        --no-deps
                         ${cargo_locked}
 
         OUTPUT_VARIABLE json

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .get_matches();
 
     let mut cmd = cargo_metadata::MetadataCommand::new();
+    cmd.no_deps();
 
     let manifest_path = matches.value_of(MANIFEST_PATH).unwrap();
     let cargo_executable = matches.value_of(CARGO_EXECUTABLE).unwrap();


### PR DESCRIPTION
We do not care about non-workspace dependencies at all. This prevents cargo metadata from fetching from the network when it is not needed at all and also makes it do less work in general.