### PR TITLE
Add "alpine" as a known triple vendor

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -361,6 +361,7 @@ function(_corrosion_parse_platform manifest rust_version target_triple)
         "nintendo"
         "nvidia"
         "openwrt"
+        "alpine"
         "unknown"
         "uwp" # aarch64-uwp-windows-msvc
         "wrs" # e.g. aarch64-wrs-vxworks


### PR DESCRIPTION
Alpine uses a separate vendor for Rust installed from aports: `$CARCH-alpine-linux-musl`

See https://gitlab.alpinelinux.org/alpine/aports/-/blob/329ba719/community/rust/alpine-target.patch