### PR TITLE
Fix cxxbridge test on windows MSVC

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - windows-2019  # Excluded for now until I have time to fix CI for windows-gnu
+          - windows-2019
           - ubuntu-latest
           - macos-12
         include:

--- a/doc/src/common_issues.md
+++ b/doc/src/common_issues.md
@@ -39,9 +39,14 @@ By default you will probably want to select the `MultiThreadedDLL` variant, unle
 This issue is quite similar to the previous one, except that this time it's a Rust library being linked
 into a C/C++ target. If it's 100% only Rust code you likely won't even have any issues.
 However, if somewhere in the dependency graph C/C++ code is built and linked into your Rust library,
-you will likely encounter this issue.
+you will likely encounter this issue. Please note, that using [cxx] counts as using C++ code and will
+lead to this issue.
+
 The previous solution should also work for this case, but additionally you [may also
 have success](https://github.com/rust-lang/rust/issues/39016#issuecomment-853964918) by using 
-`corrosion_set_env_vars(your_rust_lib "CFLAGS=-MDd" "CXXFLAGS=-MDd")`.
+`corrosion_set_env_vars(your_rust_lib "CFLAGS=-MDd" "CXXFLAGS=-MDd")` (or `-MTd` for a statically linked
+runtime).
 For debug builds, this is likely to be the preferable solution. It assumes that downstream C/C++ code
 is built by the `cc` crate, which respects the `CFLAGS` and `CXXFLAGS` environment variables.
+
+[cxx]: https://github.com/dtolnay/cxx

--- a/test/cxxbridge/CMakeLists.txt
+++ b/test/cxxbridge/CMakeLists.txt
@@ -1,11 +1,4 @@
 if(CORROSION_TESTS_CXXBRIDGE)
-    # There seems to be an upstream cxx issue, where the libcxx.rlib on the rust side uses
-    # MD_DynamicRelease regardless of the actual profile. I don't know if it is possible to setup
-    # cxx to use the correct version of the Runtimelibrary for MSVC, so for now we just don't support
-    # this usecase. If someone is interested, please feel free to investigate and fix.
-    if(Rust_CARGO_TARGET MATCHES "-msvc$")
-        return()
-    endif()
     corrosion_tests_add_test(cxxbridge_cpp2rust_1 "rust_bin"
         TEST_SRC_DIR cxxbridge_cpp2rust
         TEST_PASS_THROUGH_ARGS -DTEST_CXXBRIDGE_VARIANT1=ON

--- a/test/cxxbridge/cxxbridge_cpp2rust/CMakeLists.txt
+++ b/test/cxxbridge/cxxbridge_cpp2rust/CMakeLists.txt
@@ -15,6 +15,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
     corrosion_add_target_local_rustflags(rust_bin "-Clink-arg=-fuse-ld=lld")
 endif()
 
+if(MSVC)
+    set_target_properties(cxxbridge-cpp PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+endif()
+
 if(TEST_CXXBRIDGE_VARIANT1)
     # Variant 1: Merge the C++ User sources into the generated library target.
     target_sources(cxxbridge-cpp PRIVATE cpplib.cpp)
@@ -25,4 +29,7 @@ else()
     add_library(cpp_lib STATIC cpplib.cpp)
     target_link_libraries(cpp_lib PUBLIC cxxbridge-cpp)
     corrosion_link_libraries(rust_bin cpp_lib cxxbridge-cpp)
+    if(MSVC)
+        set_target_properties(cpp_lib PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+    endif()
 endif()

--- a/test/cxxbridge/cxxbridge_rust2cpp/CMakeLists.txt
+++ b/test/cxxbridge/cxxbridge_rust2cpp/CMakeLists.txt
@@ -9,3 +9,8 @@ corrosion_add_cxxbridge(cxxbridge-cpp CRATE cxxbridge-crate MANIFEST_PATH rust F
 
 add_executable(cxxbridge-exe main.cpp)
 target_link_libraries(cxxbridge-exe PUBLIC cxxbridge-cpp)
+
+if(MSVC)
+    # Note: This is required because we use `cxx` which uses `cc` to compile and link C++ code.
+    corrosion_set_env_vars(cxxbridge-crate "CFLAGS=-MDd" "CXXFLAGS=-MDd")
+endif()


### PR DESCRIPTION
- rust bins require the C++ code to be built with non-debug versions of msvcrt.
- C++ bins can use the debug version.