### PR TITLE
If Rust_CARGO_TARGET has been defined, make sure it is used everywhere

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -677,6 +677,9 @@ if(CORROSION_NATIVE_TOOLING)
         if(NOT _CORROSION_VERBOSE_OUTPUT_FLAG)
             set(generator_build_quiet "--quiet")
         endif()
+        if(Rust_CARGO_TARGET)
+            set(cargo_target_option "--target" ${Rust_CARGO_TARGET})
+        endif()
         # Using cargo install has the advantage of caching the build in the user .cargo directory,
         # so likely the rebuild will be very cheap even after deleting the build directory.
         execute_process(
@@ -684,6 +687,7 @@ if(CORROSION_NATIVE_TOOLING)
                     --path "."
                     --root "${generator_destination}"
                     ${generator_build_quiet}
+                    ${cargo_target_option}
                 WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../generator"
                 RESULT_VARIABLE generator_build_failed
         )


### PR DESCRIPTION
Some cargo/rustc options require an explicit target triple or else compilation will fail. If the user has set Rust_CARGO_TARGET, respect it and use it everywhere.

(Context: building w/ RUSTFLAGS='-Zsanitizer=address' set requires invoking cargo w/ `--target <triple>` for compilation to succeed or else linker errors will block compilation from completing successfully.)