### PR TITLE
Set CARGO_BUILD_RUSTC when building the Legacy Generator

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -680,13 +680,16 @@ if(CORROSION_NATIVE_TOOLING)
         # Using cargo install has the advantage of caching the build in the user .cargo directory,
         # so likely the rebuild will be very cheap even after deleting the build directory.
         execute_process(
-                # If RUSTFLAGS is set in the environment, assume it is intended to affect the
-                # final outputs, not Corrosion's internal code running at configure-time.
-                COMMAND ${CMAKE_COMMAND} -E env --unset=RUSTFLAGS
+                COMMAND ${CMAKE_COMMAND}
+                    -E env
+                        # If the Generator is built at configure of a project (instead of being pre-installed)
+                        # We don't want environment variables like `RUSTFLAGS` affecting the Generator build.
+                        --unset=RUSTFLAGS
+                        "CARGO_BUILD_RUSTC=${RUSTC_EXECUTABLE}"
                     "${CARGO_EXECUTABLE}" install
-                    --path "."
-                    --root "${generator_destination}"
-                    ${generator_build_quiet}
+                        --path "."
+                        --root "${generator_destination}"
+                        ${generator_build_quiet}
                 WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../generator"
                 RESULT_VARIABLE generator_build_failed
         )


### PR DESCRIPTION
Our `$CARGO_EXECUTABLE` is always a resolved cargo bin and never a
rustup proxy. This has the side-effect that cargo(rustup) will not
set the `RUSTUP_TOOLCHAIN` environment variable (since rustup is never
invoked).
This in turn leads to problems, since the `RUSTC` env variable cargo
exposes to  buildscripts is a `rustup` proxy, and needs to be, because
some buildscripts expect `$RUSTC` to be a rustup proxy.
The missing `RUSTUP_TOOLCHAIN` from before now leads to `$RUSTC`
invocations from buildscripts respecting the `rust-toolchain.toml`
files potentially present in the crate with the buildscript (which
can be a downstream dependency of us).
Since the toolchain tomls can contain required rust compenents, this
leads to rustup suddenly starting to install rust components, which
are only required for tests of the downstream dependencies.

The easiest way to prevent this unwanted installing of components from
our side is to simpy set `CARGO_BUILD_RUSTC` to the already resolved
`rustc`, since in that case `rustup` is never invoked.

Another solution would be if downstream dependencies would not include
the `rust-toolchain.toml` in their release crate, since it shouldn't
affect users of the library in any case anyway.