### PR TITLE
Improve the cbindgen integration

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -5,4 +5,5 @@
 - [Setup Corrosion](./setup_corrosion.md)
 - [Usage](./usage.md)
 - [Advanced](./advanced.md)
+- [FFI binding integrations](./ffi_bindings.md)
 - [Common Issues](./common_issues.md)

--- a/doc/src/ffi_bindings.md
+++ b/doc/src/ffi_bindings.md
@@ -1,0 +1,13 @@
+## cbindgen integration
+
+Corrosion offers an experimental integration of generating bindings via cbindgen.
+This is not available on a stable released version yet, and the details are subject to change.
+{{#include ../../cmake/Corrosion.cmake:corrosion_cbindgen}}
+
+### Current limitations
+
+- The current version regenerates the bindings more often then necessary to be on the safe side.
+
+## cxx integration
+
+Documentation: todo

--- a/test/cbindgen/rust2cpp/CMakeLists.txt
+++ b/test/cbindgen/rust2cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ project(test_project VERSION 0.1.0)
 include(../../test_header.cmake)
 
 corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml)
-corrosion_experimental_cbindgen(CRATE rust-lib HEADER_NAME "rust-lib.h")
+corrosion_experimental_cbindgen(TARGET rust-lib HEADER_NAME "rust-lib.h")
 
 add_executable(cpp-exe main.cpp)
 set_property(TARGET cpp-exe PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
- Add documentation
- Fix the dependency rules
- Add header to header fileset on CMake 3.23
- rename `CRATE` parameter to `TARGET` to hint that ideally this should be an imported CMake target.

There is still some work remaining before releasing this in a tagged version, but this should already be an improvement.