### PR TITLE
Simplify Argument handling

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -874,10 +874,6 @@ function(_add_cargo_build out_cargo_build_out_dir)
     if(COR_NO_DEFAULT_FEATURES)
         set(no_default_features_arg --no-default-features)
     endif()
-    if(COR_NO_STD)
-        # todo: variable unused??
-        set(no_default_libraries_arg --no-default-libraries)
-    endif()
 
     set(global_rustflags_target_property "$<TARGET_GENEX_EVAL:${target_name},$<TARGET_PROPERTY:${target_name},INTERFACE_CORROSION_RUSTFLAGS>>")
     set(local_rustflags_target_property  "$<TARGET_GENEX_EVAL:${target_name},$<TARGET_PROPERTY:${target_name},INTERFACE_CORROSION_LOCAL_RUSTFLAGS>>")

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -862,13 +862,6 @@ function(_add_cargo_build out_cargo_build_out_dir)
         message(VERBOSE "CORROSION_LINKER_PREFERENCE for target ${target_name}: ${CORROSION_LINKER_PREFERENCE}")
     endif()
 
-    # todo: variable unused??
-    if (NOT CMAKE_CONFIGURATION_TYPES)
-        set(target_dir ${CMAKE_CURRENT_BINARY_DIR})
-    else()
-        set(target_dir ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
-    endif()
-
     # If a CMake sysroot is specified, forward it to the linker rustc invokes, too. CMAKE_SYSROOT is documented
     # to be passed via --sysroot, so we assume that when it's set, the linker supports this option in that style.
     if(CMAKE_CROSSCOMPILING AND CMAKE_SYSROOT)

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -42,8 +42,8 @@ endfunction()
 # Add targets (crates) of one package
 function(_generator_add_package_targets)
     set(OPTIONS NO_LINKER_OVERRIDE)
-    set(ONE_VALUE_KEYWORDS WORKSPACE_MANIFEST_PATH PACKAGE_MANIFEST_PATH PACKAGE_NAME PACKAGE_VERSION TARGETS_JSON PROFILE OUT_CREATED_TARGETS)
-    set(MULTI_VALUE_KEYWORDS CRATE_TYPES ADDITIONAL_CARGO_FLAGS)
+    set(ONE_VALUE_KEYWORDS WORKSPACE_MANIFEST_PATH PACKAGE_MANIFEST_PATH PACKAGE_NAME PACKAGE_VERSION TARGETS_JSON OUT_CREATED_TARGETS)
+    set(MULTI_VALUE_KEYWORDS CRATE_TYPES)
     cmake_parse_arguments(PARSE_ARGV 0 GAPT "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
 
     if(DEFINED GAPT_UNPARSED_ARGUMENTS)
@@ -54,8 +54,6 @@ function(_generator_add_package_targets)
     endif()
 
     _corrosion_option_passthrough_helper(NO_LINKER_OVERRIDE GAPT no_linker_override)
-    _corrosion_arg_passthrough_helper(PROFILE GAPT profile)
-    _corrosion_arg_passthrough_helper(ADDITIONAL_CARGO_FLAGS GAPT additional_cargo_flags)
 
     set(workspace_manifest_path "${GAPT_WORKSPACE_MANIFEST_PATH}")
     set(package_manifest_path "${GAPT_PACKAGE_MANIFEST_PATH}")
@@ -132,9 +130,7 @@ function(_generator_add_package_targets)
                 TARGET_KINDS "${kinds}"
                 BYPRODUCTS "${byproducts}"
                 # Optional
-                ${profile}
                 ${no_linker_override}
-                ${additional_cargo_flags}
             )
             if(archive_byproducts)
                 _corrosion_copy_byproducts(
@@ -173,9 +169,7 @@ function(_generator_add_package_targets)
                 TARGET_KINDS "bin"
                 BYPRODUCTS "${byproducts}"
                 # Optional
-                ${profile}
                 ${no_linker_override}
-                ${additional_cargo_flags}
             )
             _corrosion_copy_byproducts(
                     ${target_name} RUNTIME_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${bin_byproduct}"
@@ -204,8 +198,8 @@ endfunction()
 # `MANIFEST_PATH`.
 function(_generator_add_cargo_targets)
     set(options NO_LINKER_OVERRIDE)
-    set(one_value_args MANIFEST_PATH PROFILE IMPORTED_CRATES)
-    set(multi_value_args CRATES CRATE_TYPES ADDITIONAL_CARGO_FLAGS)
+    set(one_value_args MANIFEST_PATH IMPORTED_CRATES)
+    set(multi_value_args CRATES CRATE_TYPES)
     cmake_parse_arguments(
         GGC
         "${options}"
@@ -216,8 +210,6 @@ function(_generator_add_cargo_targets)
 
     _corrosion_option_passthrough_helper(NO_LINKER_OVERRIDE GGC no_linker_override)
     _corrosion_arg_passthrough_helper(CRATE_TYPES GGC crate_types)
-    _corrosion_arg_passthrough_helper(PROFILE GGC cargo_profile)
-    _corrosion_arg_passthrough_helper(ADDITIONAL_CARGO_FLAGS GGC additional_cargo_flags)
 
     _cargo_metadata(json "${GGC_MANIFEST_PATH}")
     string(JSON packages GET "${json}" "packages")
@@ -277,9 +269,7 @@ function(_generator_add_cargo_targets)
             TARGETS_JSON "${targets}"
             OUT_CREATED_TARGETS curr_created_targets
             ${no_linker_override}
-            ${cargo_profile}
             ${crate_types}
-            ${additional_cargo_flags}
         )
         list(APPEND created_targets "${curr_created_targets}")
     endforeach()

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -89,22 +89,8 @@ impl CargoTarget {
     pub fn emit_cmake_target(
         &self,
         out_file: &mut dyn std::io::Write,
-        cargo_profile: Option<&str>,
-        additional_cargo_flags: &Vec<&str>,
         passthrough_add_cargo_build: &str,
     ) -> Result<(), Box<dyn Error>> {
-        let cargo_build_profile_option = if let Some(profile) = cargo_profile {
-            format!("PROFILE \"{}\"", profile)
-        } else {
-            String::default()
-        };
-
-        let additional_cargo_flags_kw = if additional_cargo_flags.is_empty() {
-            ""
-        } else {
-            "ADDITIONAL_CARGO_FLAGS"
-        };
-
         writeln!(
             out_file,
             "set(byproducts \"\")
@@ -187,10 +173,8 @@ impl CargoTarget {
                 TARGET \"{target_name}\"
                 MANIFEST_PATH \"{package_manifest_path}\"
                 WORKSPACE_MANIFEST_PATH \"{workspace_manifest_path}\"
-                {profile_option}
                 TARGET_KINDS {target_kinds}
                 BYPRODUCTS \"${{byproducts}}\"
-                {additional_cargo_flags_kw} {additional_cargo_flags}
                 {passthrough_add_cargo_build}
             )
 
@@ -223,10 +207,7 @@ impl CargoTarget {
             target_name = self.cargo_target.name,
             package_manifest_path = self.cargo_package.manifest_path.as_str().replace("\\", "/"),
             workspace_manifest_path = ws_manifest,
-            profile_option = cargo_build_profile_option,
             target_kinds = target_kinds,
-            additional_cargo_flags = additional_cargo_flags.join(" "),
-            additional_cargo_flags_kw = additional_cargo_flags_kw,
             passthrough_add_cargo_build = passthrough_add_cargo_build,
 
         )?;


### PR DESCRIPTION
We now have access to a list of imported crates
in `corrosion_import_crate`, so
instead of passing through arguments like
FEATURES, PROFILE and FLAGS to `_add_cargo_build`
it is much simpler to simply initialize the per-target properties from corrosion_import_crate.

The user can still override these per crate as usual, this simply removes a lot of code which becomes redundant, if you only read from the target property instead of additionally having a pass-through option to consider.