### PR TITLE
Cleanup Linker selection code

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,7 @@ jobs:
             arch: x86_64
             abi: darwin
             os: macos-12
-          - rust: stable
+          - rust: 1.54
             cmake: 3.19.0
             generator: ninja
             arch: x86_64
@@ -90,7 +90,7 @@ jobs:
             arch: x86_64
             abi: gnu
             cmake: 3.20.0
-            rust: stable
+            rust: 1.54
             generator: ninja-multiconfig
 
         exclude:

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -587,6 +587,12 @@ if (NOT Rust_CARGO_TARGET_CACHED)
     message(STATUS "Rust Target: ${Rust_CARGO_TARGET_CACHED}")
 endif()
 
+if(Rust_CARGO_TARGET_CACHED STREQUAL Rust_DEFAULT_HOST_TARGET)
+    set(Rust_CROSSCOMPILING FALSE CACHE INTERNAL "Rust is configured for cross-compiling")
+else()
+    set(Rust_CROSSCOMPILING TRUE  CACHE INTERNAL "Rust is configured for cross-compiling")
+endif()
+
 # Set the input variables as non-cache variables so that the variables are available after
 # `find_package`, even if the values were evaluated to defaults.
 foreach(_VAR ${_Rust_USER_VARS})

--- a/test/cpp2rust/cpp2rust/rust/build.rs
+++ b/test/cpp2rust/cpp2rust/rust/build.rs
@@ -1,0 +1,4 @@
+// Build-scripts also need to be linked, so just add a dummy buildscript ensuring this works.
+fn main() {
+    println!("Build-script is running.")
+}

--- a/test/parse_target_triple/CMakeLists.txt
+++ b/test/parse_target_triple/CMakeLists.txt
@@ -1,5 +1,10 @@
 corrosion_tests_add_test(parse_target_triple "")
+corrosion_tests_add_test(parse_target_triple_should_fail "")
 
 set_tests_properties("parse_target_triple_build" PROPERTIES FAIL_REGULAR_EXPRESSION
         "CMake Warning"
         )
+
+set_tests_properties("parse_target_triple_should_fail_build" PROPERTIES PASS_REGULAR_EXPRESSION
+    "CMake Warning"
+    )

--- a/test/parse_target_triple/parse_target_triple/CMakeLists.txt
+++ b/test/parse_target_triple/parse_target_triple/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required(VERSION 3.15)
 project(test_project VERSION 0.1.0)
 include(../../test_header.cmake)
 
-# Custom json file. The file doesn't need to exist for the test.
-_corrosion_parse_platform("Cargo.toml" "1.55" "../../blah/x86_64-unknown-custom-gnu.json")
-_corrosion_parse_platform("Cargo.toml" "1.55" "x86_64-unknown-custom-gnu.json")
-_corrosion_parse_platform("Cargo.toml" "1.55" "/path/to/x86_64-unknown-custom-gnu.json")
-_corrosion_parse_platform("Cargo.toml" "1.55" "../../blah/x86_64-custom_os.json")
+# Todo: Test if the output matches expectations.
+_corrosion_parse_target_triple("../../blah/x86_64-unknown-custom-gnu.json" arch vendor os env)
+_corrosion_parse_target_triple("x86_64-unknown-custom-gnu.json" arch vendor os env)
+_corrosion_parse_target_triple("/path/to/x86_64-unknown-custom-musl.json" arch vendor os env)
+_corrosion_parse_target_triple("../../blah/x86_64-custom_os.json" arch vendor os env)
 
 # List of builtin targets aquired via `rustup target list` with rust 1.64 on Linux.
 set(rustup_shipped_targets
@@ -101,5 +101,5 @@ set(rustup_shipped_targets
 )
 
 foreach(target ${rustup_shipped_targets})
-    _corrosion_parse_platform("Cargo.toml" "1.55" "${target}")
+    _corrosion_parse_target_triple("${target}"  arch vendor os env)
 endforeach()

--- a/test/parse_target_triple/parse_target_triple/Cargo.toml
+++ b/test/parse_target_triple/parse_target_triple/Cargo.toml
@@ -1,1 +1,0 @@
-# Pseudo manifest, just used in CMake to set some source file properties.

--- a/test/parse_target_triple/parse_target_triple_should_fail/CMakeLists.txt
+++ b/test/parse_target_triple/parse_target_triple_should_fail/CMakeLists.txt
@@ -3,8 +3,4 @@ cmake_minimum_required(VERSION 3.15)
 project(test_project VERSION 0.1.0)
 include(../../test_header.cmake)
 
-# Check if parsing fails
-_corrosion_parse_platform("Cargo.toml" "1.55" "x86_64-unknown-linux-gnu-toomuch")
-
-
-
+_corrosion_parse_target_triple("x86_64-unknown-linux-gnu-toomuch" arch vendor os env)

--- a/test/parse_target_triple/parse_target_triple_should_fail/Cargo.toml
+++ b/test/parse_target_triple/parse_target_triple_should_fail/Cargo.toml
@@ -1,1 +1,0 @@
-# Pseudo manifest, just used in CMake to set some source file properties.

--- a/test/rust2cpp/rust2cpp/rust/build.rs
+++ b/test/rust2cpp/rust2cpp/rust/build.rs
@@ -1,0 +1,4 @@
+// Build-scripts also need to be linked, so just add a dummy buildscript ensuring this works.
+fn main() {
+    println!("Build-script is running.")
+}


### PR DESCRIPTION
Corrosion selects a default linker to ensure builds work as expected. This is required to support:
- Linking C++ libraries (i.e. including the c++ stdlib)
- Select a correct linker for cross-compiling.

Instead of relying on CMake implementation details, we now:
- select the C++ compiler for targets where C++ is linked into. Previously we used the C++ compiler if C++ was enabled as a language
- Assume that the C language is enabled if C++ is not.