### PR TITLE
Improve required library detection for staticlibs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,11 +17,23 @@
   default they won't have an `soname` field.
   If you add a rustflag like `-Clink-arg=-Wl,-soname,libmycrate.so` in your project,
   you should set this property to false on the shared rust library.
+- Corrosion now uses a mechanism to determine which native libraries need to be linked with
+  Rust `staticlib` targets into C/C++ targets. The previous mechanism contained a hardcoded list.
+  The new mechanism asks `rustc` which libraries are needed at minimum for a given
+  target triple (with `std` support). This should not be a breaking change, but if you
+  do encounter a new linking issue when upgrading with `staticlib` targets, please open an
+  issue.
 
 ## New features
 
 - `corrosion_import_crate()` has two new options `LOCKED` and `FROZEN` which pass the 
   `--locked` and `--frozen` flags to all invocations of cargo. Only with CMake >= 3.19.
+- `FindRust` now provides cache variables containing information on the default host
+  target triple:
+  - `Rust_CARGO_HOST_TARGET_ARCH`
+  - `Rust_CARGO_HOST_TARGET_VENDOR`
+  - `Rust_CARGO_HOST_TARGET_OS`
+  - `Rust_CARGO_HOST_TARGET_ENV`
 
 ## Other changes
 

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1712,10 +1712,15 @@ function(corrosion_experimental_cbindgen)
     if(installed_cbindgen)
         set(cbindgen "${installed_cbindgen}")
     else()
+        set(local_cbindgen_install_dir "${CMAKE_BINARY_DIR}/corrosion/cbindgen")
+        unset(executable_postfix)
+        if(Rust_CARGO_HOST_TARGET_OS STREQUAL "windows")
+            set(executable_postfix ".exe")
+        endif()
+        set(cbindgen "${local_cbindgen_install_dir}/bin/cbindgen${executable_postfix}")
         if(NOT TARGET "_corrosion_cbindgen")
-            set(local_cbindgen_install_dir "${CMAKE_BINARY_DIR}/corrosion/cbindgen")
             file(MAKE_DIRECTORY "${local_cbindgen_install_dir}")
-            add_custom_command(OUTPUT "${local_cbindgen_install_dir}/bin/cbindgen"
+            add_custom_command(OUTPUT "${cbindgen}"
                 COMMAND ${CMAKE_COMMAND}
                 -E env
                 "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
@@ -1726,10 +1731,9 @@ function(corrosion_experimental_cbindgen)
                 COMMENT "Building cbindgen"
                 )
             add_custom_target("_corrosion_cbindgen"
-                DEPENDS "${local_cbindgen_install_dir}/bin/cbindgen"
+                DEPENDS "${cbindgen}"
                 )
         endif()
-        set(cbindgen "${local_cbindgen_install_dir}/bin/cbindgen")
     endif()
 
     set(corrosion_generated_dir "${CMAKE_CURRENT_BINARY_DIR}/corrosion_generated")

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -118,6 +118,13 @@ versions individually.
 - `Rust_LLVM_VERSION<_MAJOR|_MINOR|_PATCH>` - The LLVM version used by rustc.
 - `Rust_IS_NIGHTLY` - 1 if a nightly toolchain is used, otherwise 0. Useful for selecting an unstable feature for a
   crate, that is only available on nightly toolchains.
+- Cache variables containing information based on the target triple for the selected target 
+  as well as the default host target:
+  - `Rust_CARGO_TARGET_ARCH`, `Rust_CARGO_HOST_TARGET_ARCH`: e.g. `x86_64` or `aarch64`
+  - `Rust_CARGO_TARGET_VENDOR`, `Rust_CARGO_HOST_TARGET_VENDOR`: e.g. `apple`, `pc`, `unknown` etc.
+  - `Rust_CARGO_TARGET_OS`, `Rust_CARGO_HOST_TARGET_OS`:  e.g. `darwin`, `linux`, `windows`, `none`
+  - `Rust_CARGO_TARGET_ENV`, `Rust_CARGO_HOST_TARGET_ENV`: e.g. `gnu`, `musl`
+
 
 
 


### PR DESCRIPTION
Instead of hand maintaining a list of required libraries, it is more efficient to just ask `rustc` what libraries are needed to link.

Using a demo project will not give a full list, but at least a minimum list of required dependencies - which is the same situation as now.

In the future we could expand this by passing arguments from the cargo build step to the link-step via a file.
But that needs more investigation, so we do this improvement first.