### PR TITLE
Improve cxxbridge integration

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1477,7 +1477,10 @@ function(corrosion_add_cxxbridge cxx_target)
             add_custom_command(OUTPUT "${CMAKE_BINARY_DIR}/corrosion/cxxbridge_v${cxx_required_version}/bin/cxxbridge"
                 COMMAND
                 ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/corrosion/cxxbridge_v${cxx_required_version}"
-                COMMAND ${_CORROSION_CARGO} install
+                COMMAND
+                    ${CMAKE_COMMAND} -E env
+                        "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
+                    ${_CORROSION_CARGO} install
                     cxxbridge-cmd
                     --version "${cxx_required_version}"
                     --root "${CMAKE_BINARY_DIR}/corrosion/cxxbridge_v${cxx_required_version}"

--- a/test/cxxbridge/CMakeLists.txt
+++ b/test/cxxbridge/CMakeLists.txt
@@ -1,9 +1,12 @@
 if(CORROSION_TESTS_CXXBRIDGE)
     corrosion_tests_add_test(cxxbridge_cpp2rust_1 "rust_bin"
         TEST_SRC_DIR cxxbridge_cpp2rust
-        TEST_PASS_THROUGH_ARGS -DTEST_CXXBRIDGE_VARIANT1=ON
+        PASS_THROUGH_ARGS -DTEST_CXXBRIDGE_VARIANT1=ON
     )
-    corrosion_tests_add_test(cxxbridge_cpp2rust_2 "rust_bin" TEST_SRC_DIR cxxbridge_cpp2rust)
+    corrosion_tests_add_test(cxxbridge_cpp2rust_2 "rust_bin"
+            TEST_SRC_DIR cxxbridge_cpp2rust
+            PASS_THROUGH_ARGS -DTEST_CXXBRIDGE_VARIANT2=ON
+    )
     corrosion_tests_add_test(cxxbridge_rust2cpp "cxxbridge-exe")
 
     set_tests_properties("cxxbridge_cpp2rust_1_run_rust_bin"

--- a/test/cxxbridge/cxxbridge_cpp2rust/CMakeLists.txt
+++ b/test/cxxbridge/cxxbridge_cpp2rust/CMakeLists.txt
@@ -6,7 +6,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED 1)
 
 corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml)
 corrosion_add_cxxbridge(cxxbridge-cpp CRATE rust_bin FILES lib.rs)
-target_include_directories(cxxbridge-cpp PUBLIC "include")
+target_include_directories(cxxbridge-cpp PRIVATE "include")
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
     OR (CMAKE_SYSTEM_NAME STREQUAL "Windows"
         AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -23,13 +24,16 @@ if(TEST_CXXBRIDGE_VARIANT1)
     # Variant 1: Merge the C++ User sources into the generated library target.
     target_sources(cxxbridge-cpp PRIVATE cpplib.cpp)
     corrosion_link_libraries(rust_bin cxxbridge-cpp)
-else()
+elseif(TEST_CXXBRIDGE_VARIANT2)
     # Variant 2: Create a separate C++ library and link both the User library and
     # the generated library into rust
     add_library(cpp_lib STATIC cpplib.cpp)
+    target_include_directories(cpp_lib PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include")
     target_link_libraries(cpp_lib PUBLIC cxxbridge-cpp)
     corrosion_link_libraries(rust_bin cpp_lib cxxbridge-cpp)
     if(MSVC)
         set_target_properties(cpp_lib PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
     endif()
+else()
+    message(FATAL_ERROR "Internal test error - required option not defined")
 endif()

--- a/test/cxxbridge/cxxbridge_cpp2rust/cpplib.cpp
+++ b/test/cxxbridge/cxxbridge_cpp2rust/cpplib.cpp
@@ -1,12 +1,11 @@
 #include <iostream>
 #include "cpplib.h"
 #include "cxxbridge-cpp/lib.h"
-
-// todo: the cxx cli does not seem to generate this binding.
-//std::ostream &operator<<(std::ostream &, const rust::Str &);
+#include "rust/cxx.h"
 
 RsImage read_image(rust::Str path) {
-    //std::cout << path << std::endl;
+    std::cout << "read_image called" << std::endl;
+    std::cout << path << std::endl;
     Rgba c = { 1.0, 2.0, 3.0, 4.0};
     RsImage v = { 1, 1, c};
     return v;

--- a/test/cxxbridge/cxxbridge_cpp2rust/rust/src/main.rs
+++ b/test/cxxbridge/cxxbridge_cpp2rust/rust/src/main.rs
@@ -9,5 +9,6 @@ fn main() {
         a: 4.0,
     }};
     let actual = read_image("dummy path");
+    println!("returned from C++");
     assert_eq!(actual, expected)
 }


### PR DESCRIPTION
Generate `rust/cxx.h` in addition to the per target header.