### PR TITLE
cxxbridge: set `cxx_std_11` as PUBLIC compile feature

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1571,6 +1571,10 @@ function(corrosion_add_cxxbridge cxx_target)
             $<BUILD_INTERFACE:${generated_dir}/include>
             $<INSTALL_INTERFACE:include>
     )
+    
+    # cxx generated code is using c++11 features in headers, so propagate c++11 as minimal requirement
+    target_compile_features(${cxx_target} PUBLIC cxx_std_11)
+    
     # Todo: target_link_libraries is only necessary for rust2c projects.
     # It is possible that checking if the rust crate is an executable is a sufficient check,
     # but some more thought may be needed here.


### PR DESCRIPTION
This is not catched by tests in macos because the tests are setting `CMAKE_CXX_STANDARD`.

https://github.com/corrosion-rs/corrosion/blob/e516737bf4987d000353045133c2f82b23553490/test/cxxbridge/cxxbridge_cpp2rust/CMakeLists.txt#L4-L5

Default compilation on macos fail, if `CMAKE_CXX_STANDARD` is not set.