### PR TITLE
Fix unnecessary recompilations

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -885,7 +885,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
                 # Any arguments to cargo must be placed before this line
                 ${local_rustflags_delimiter}
                 ${linker_arg}
-                ${linker_flavor_arg}
+                # ${linker_flavor_arg}
                 ${local_rustflags_genex}
 
         # Note: Adding `build_byproducts` (the byproducts in the cargo target directory) here

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -824,7 +824,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
     unset(default_target_linker)
     # With the MSVC ABI rustc only supports directly invoking the linker - Invoking cl as the linker driver is not supported.
     if(NOT (Rust_CARGO_TARGET_ENV STREQUAL "msvc" OR COR_NO_LINKER_OVERRIDE))
-        set(default_target_linker "$<IF:$<BOOL:${target_uses_cxx}>,${CMAKE_CXX_COMPILER},${CMAKE_C_COMPILER}>")
+        set(default_target_linker "$<IF:$<BOOL:${target_uses_cxx}>,clang,abcdefg>")#${CMAKE_CXX_COMPILER},${CMAKE_C_COMPILER}>")
     endif()
     if(NOT (Rust_CARGO_HOST_ENV STREQUAL "msvc" OR COR_NO_LINKER_OVERRIDE))
         # CMake doesn't select any compiler for the host, so just default to cxx for C++ and cc otherwise.

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -824,7 +824,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
     unset(default_target_linker)
     # With the MSVC ABI rustc only supports directly invoking the linker - Invoking cl as the linker driver is not supported.
     if(NOT (Rust_CARGO_TARGET_ENV STREQUAL "msvc" OR COR_NO_LINKER_OVERRIDE))
-        set(default_target_linker "$<IF:$<BOOL:${target_uses_cxx}>,clang,abcdefg>")#${CMAKE_CXX_COMPILER},${CMAKE_C_COMPILER}>")
+        set(default_target_linker "$<IF:$<BOOL:${target_uses_cxx}>,${CMAKE_CXX_COMPILER},${CMAKE_C_COMPILER}>")
     endif()
     if(NOT (Rust_CARGO_HOST_ENV STREQUAL "msvc" OR COR_NO_LINKER_OVERRIDE))
         # CMake doesn't select any compiler for the host, so just default to cxx for C++ and cc otherwise.

--- a/test/multitarget/multitarget/Cargo.toml
+++ b/test/multitarget/multitarget/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [lib]
 name = "multitarget_lib"
-crate-type=["lib", "staticlib", "cdylib"]
+crate-type=["lib"]
 
 [[bin]]
 name = "bin1"


### PR DESCRIPTION
Changing / unsetting `CARGO_TARGET_xyz_LINKER` causes cargo to recompile all dependencies, which is unnecessary.
To avoid this we now set the linker directly for the last `rustc` invocation. This has the side-effect of not affecting the linker for potential compilations with `cc` in downstream build scripts, which should be an improvement.

We also now pass `linker-flavor` as an argument, which fixes some linker inference issues in older rust versions.

Fixes #386