### PR TITLE
Improve Multi-Config error message

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.15)
 
 if (CMAKE_CONFIGURATION_TYPES AND CMAKE_VERSION VERSION_LESS 3.20.0)
     message(FATAL_ERROR "Corrosion requires at least CMake 3.20 with Multi-Config Generators such as "
-       "\"Ninja Multi-Config\" or Visual Studio. "
-       "Please use a different generator or update to cmake >= 3.20.")
+        "\"Ninja Multi-Config\" or Visual Studio. "
+        "Please use a different generator or update to cmake >= 3.20.\n"
+        "Note: You are using CMake ${CMAKE_VERSION} (Path: `${CMAKE_COMMAND}`) with "
+        " the `${CMAKE_GENERATOR}` Generator."
+    )
 endif()
 
 option(CORROSION_VERBOSE_OUTPUT "Enables verbose output from Corrosion and Cargo" OFF)


### PR DESCRIPTION
Add the actual CMake version and the path to the used cmake version to the error message. The CMake version used by the user could be e.g. a bundled CMake version, which may not be obvious to the user. Printing the path to the used CMake executable should make such cases obvious.