### PR TITLE
Fix cargo tree to use the correct rustc executable

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1482,7 +1482,9 @@ function(corrosion_add_cxxbridge cxx_target)
 
     get_filename_component(manifest_dir ${manifest_path} DIRECTORY)
 
-    execute_process(COMMAND ${_CORROSION_CARGO} tree -i cxx --depth=0
+    execute_process(COMMAND ${CMAKE_COMMAND} -E env
+        "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
+        ${_CORROSION_CARGO} tree -i cxx --depth=0
         WORKING_DIRECTORY "${manifest_dir}"
         RESULT_VARIABLE cxx_version_result
         OUTPUT_VARIABLE cxx_version_output


### PR DESCRIPTION
Sorry, I added this code (in https://github.com/corrosion-rs/corrosion/pull/373) in order to fix an error with `cargo` not being found when it is not in path, but it seems that my patch was not good enough as it now fails because cargo can't find `rustc`... I think this patch makes it work (I can only test this locally because the github CI seems to have the Rust installation configured in PATH)