### PR TITLE
Install selected toolchain via rustup

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -221,6 +221,7 @@ if (DEFINED Rust_TOOLCHAIN)
     # If the user specifies `Rust_TOOLCHAIN`, then look for `rustup` first, rather than `rustc`.
     find_program(Rust_RUSTUP rustup PATHS "$ENV{HOME}/.cargo/bin")
     if(Rust_RUSTUP)
+        execute_process(COMMAND "${Rust_RUSTUP}" install "${Rust_TOOLCHAIN}")
         set(_RESOLVE_RUSTUP_TOOLCHAINS ON)
     else()
         set(_RESOLVE_RUSTUP_TOOLCHAINS OFF)


### PR DESCRIPTION
Hey :)

I'm not sure if this is the correct way to implement this. I wrote this to bridge a gap in a project that uses `rust-toolchain.toml` to select a toolchain (and possibly download it). It seems that corrosion does support choosing the toolchain that is specified in `rust-toolchain.toml` (because it appears as an override toolchain in rustup and corrosion sets the `_TOOLCHAIN_OVERRIDE` setting), but only if that toolchain is installed, contrary to cargo which downloads the toolchain automatically.

There seems to be a fundamental issue here where rustup doesn't show a toolchain override from `rust-toolchain.toml` until cargo (or something else) ran and installed it, and there doesn't seem to be any rustup subcommand to install whatever toolchain is required by the current project. I thought the corrosion-specific toolchain override is the place to bridge that gap until rustup gains the ability to bootstrap the correct toolchain as the override settings dictate.
