### PR TITLE
Fix passing target when linking via clang

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -843,7 +843,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
     set(linker "$<IF:${explicit_linker_defined},${explicit_linker_property},${default_linker}>")
     set(cargo_target_linker $<$<BOOL:${linker}>:${cargo_target_linker_var}=${linker}>)
 
-    if(Rust_CROSSCOMPILING AND ("${CMAKE_C_COMPILER_TARGET}" OR "${CMAKE_CXX_COMPILER_TARGET}"))
+    if(Rust_CROSSCOMPILING AND (CMAKE_C_COMPILER_TARGET OR CMAKE_CXX_COMPILER_TARGET))
         set(linker_target_triple "$<IF:$<BOOL:${target_uses_cxx}>,${CMAKE_CXX_COMPILER_TARGET},${CMAKE_C_COMPILER_TARGET}>")
         set(rustflag_linker_arg "-Clink-args=--target=${linker_target_triple}")
         set(rustflag_linker_arg "$<${if_not_host_build_condition}:${rustflag_linker_arg}>")


### PR DESCRIPTION
When the linker is invoked via Rust, and set to `clang` or a different compiler that requires a target parameter, the --target parameter must be passed, otherwise the host linker could be invoked.

The condition checkingt his was wrong, because CMake evaluates quoted strings to false, unless the content is explicitely one of the true values. We need to use the unquoted variable instead in order to have the desired behavior of checking if the compiler target variable is set.