### PR TITLE
Refactor detecting required link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Corrosion
     # tagged release. Users don't need to care about this, it is mainly to
     # clearly see in configure logs which version was used, without needing to
     # rely on `git`, since Corrosion may be installed or otherwise packaged.
-    VERSION 0.4.2
+    VERSION 0.4.2.1
     LANGUAGES NONE
     HOMEPAGE_URL "https://corrosion-rs.github.io/corrosion/"
 )


### PR DESCRIPTION
Do not rely on cargo new generating a valid Cargo.toml or valid package and instead ship everything we need ourselves.