### PR TITLE
Fix the PROFILE option with old CMake versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,19 @@ jobs:
       os: windows-2019
       rust: 1.46.0
 
+  test_legacy_stable:
+    name: Legacy CMake + stable Rust
+    uses: ./.github/workflows/test_legacy.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2019 # windows-latest is currently not having a supported MSVC compiler
+          - ubuntu-20.04
+          - macos-12
+    with:
+      os: ${{ matrix.os }}
+      rust: stable
 
   test:
     name: Test Corrosion
@@ -305,6 +318,7 @@ jobs:
       - test_legacy_linux
       - test_legacy_mac
       - test_legacy_windows
+      - test_legacy_stable
       - test
       - test_msvc
       - test_cxxbridge

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Fixes
+
+- Fix the PROFILE option with CMake < 3.19 [#427]
+
 # 0.4.2 (2023-07-16)
 
 ### Fixes

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1022,8 +1022,6 @@ function(corrosion_import_crate)
                     " cannot predict. Please consider using a custom cargo profile which inherits from the"
                     " built-in profile instead."
             )
-        else()
-            set(cargo_profile_native_generator --profile=${COR_PROFILE})
         endif()
     endif()
 


### PR DESCRIPTION
- Fix the PROFILE option for the legacy Generator
- Additionally test old CMake versions with the newest stable Rust version in CI (which catches the issue)