### PR TITLE
(chore): bump `proc-macro2` `1.0.5x` -> `1.0.65`

### DIFF
--- a/generator/Cargo.lock
+++ b/generator/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [

--- a/test/cxxbridge/cxxbridge_cpp2rust/rust/Cargo.lock
+++ b/test/cxxbridge/cxxbridge_cpp2rust/rust/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [

--- a/test/cxxbridge/cxxbridge_rust2cpp/rust/Cargo.lock
+++ b/test/cxxbridge/cxxbridge_rust2cpp/rust/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [


### PR DESCRIPTION
# Changes

- Fixes #428
- Bumps `proc-macro2` to version `1.0.65`

## Notes

As `proc-macro2` is an _internal_ dependency, meaning it is a dependency required indirectly, the only way to bump it is to directly edit `Cargo.lock`.

This is safe, HOWEVER, blindly running cargo update/add MAY revert these changes in the near-ish future, so be aware of that :)