### PR TITLE
Fix Legacy CMake Generator with nightly Rust

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,13 @@ jobs:
       os: ${{ matrix.os }}
       rust: stable
 
+  test_legacy_nightly:
+    name: Legacy CMake + nightly Rust
+    uses: ./.github/workflows/test_legacy.yaml
+    with:
+      os: ubuntu-20.04
+      rust: nightly
+
   test:
     name: Test Corrosion
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,18 @@ jobs:
       os: ubuntu-20.04
       rust: nightly
 
+  test_legacy_new_lockfile_msrv:
+    name: Test MSRV of the new lockfile
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        id: install_rust
+        uses: dtolnay/rust-toolchain@1.56
+      - name: Test Generator build with MSRV
+        run: cargo build
+        working-directory: generator
+
   test:
     name: Test Corrosion
     runs-on: ${{ matrix.os }}
@@ -326,6 +338,7 @@ jobs:
       - test_legacy_mac
       - test_legacy_windows
       - test_legacy_stable
+      - test_legacy_new_lockfile_msrv
       - test
       - test_msvc
       - test_cxxbridge

--- a/.github/workflows/test_legacy.yaml
+++ b/.github/workflows/test_legacy.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{github.workspace}}/corrosion-prebuilt-generator
-          key: ${{ runner.os }}-generator-${{ hashFiles('generator/src/**', 'generator/Cargo.toml', 'generator/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ inputs.rust }}-generator-${{ hashFiles('generator/src/**', 'generator/Cargo.toml', 'generator/Cargo.lock') }}
       - name: Setup Environment and Configure CMake
         uses: "./.github/actions/setup_test"
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,15 +88,11 @@ endif()
 include(GNUInstallDirs)
 
 if(CORROSION_INSTALL_EXECUTABLE)
-    # Builds the generator executable
-    corrosion_import_crate(MANIFEST_PATH generator/Cargo.toml)
-
-    set(_CORROSION_GENERATOR_DESTINATION "${CMAKE_INSTALL_FULL_LIBEXECDIR}")
-
-    corrosion_install(
-        TARGETS corrosion-generator
-        DESTINATION "${_CORROSION_GENERATOR_DESTINATION}"
+    get_property(
+            _CORROSION_GENERATOR_EXE
+            TARGET Corrosion::Generator PROPERTY IMPORTED_LOCATION
     )
+    install(PROGRAMS "${_CORROSION_GENERATOR_EXE}" DESTINATION "${CMAKE_INSTALL_FULL_LIBEXECDIR}")
 else()
     message(DEBUG "Not installing corrosion-generator since "
         "`CORROSION_INSTALL_EXECUTABLE` is set to ${CORROSION_INSTALL_EXECUTABLE}"

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -571,20 +571,19 @@ endif()
 if(CORROSION_NATIVE_TOOLING)
     if (NOT TARGET Corrosion::Generator )
         add_subdirectory(generator)
-    else()
-        get_property(
-                _CORROSION_GENERATOR_EXE
-                TARGET Corrosion::Generator PROPERTY IMPORTED_LOCATION
-        )
     endif()
+    get_property(
+        _CORROSION_GENERATOR_EXE
+        TARGET Corrosion::Generator PROPERTY IMPORTED_LOCATION
+    )
     set(
-_CORROSION_GENERATOR
-            ${CMAKE_COMMAND} -E env
+        _CORROSION_GENERATOR
+        ${CMAKE_COMMAND} -E env
             CARGO_BUILD_RUSTC=${RUSTC_EXECUTABLE}
             ${_CORROSION_GENERATOR_EXE}
             --cargo ${CARGO_EXECUTABLE}
             ${_CORROSION_VERBOSE_OUTPUT_FLAG}
-            CACHE INTERNAL "corrosion-generator runner"
+        CACHE INTERNAL "corrosion-generator runner"
     )
 endif()
 

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -1,8 +1,19 @@
 message(STATUS "Building CMake Generator for Corrosion - This may take a while")
 
-set(generator_destination "${CMAKE_CURRENT_BINARY_DIR}/legacy_generator_src")
+set(generator_src "${CMAKE_CURRENT_BINARY_DIR}/legacy_generator_src")
 set(generator_destination "${CMAKE_CURRENT_BINARY_DIR}/legacy_generator")
 set(generator_build_quiet "")
+
+file(MAKE_DIRECTORY "${generator_src}")
+file(COPY src DESTINATION "${generator_src}")
+if(Rust_VERSION VERSION_LESS "1.56")
+    message(STATUS "Corrosion Generator: Using Compatibility lock file, due to rust version less than 1.56")
+    file(COPY Compat.Cargo.lock Compat.Cargo.toml DESTINATION "${generator_src}")
+    file(RENAME "${generator_src}/Compat.Cargo.lock" "${generator_src}/Cargo.lock")
+    file(RENAME "${generator_src}/Compat.Cargo.toml" "${generator_src}/Cargo.toml")
+else()
+    file(COPY Cargo.lock Cargo.toml DESTINATION "${generator_src}")
+endif()
 
 # Using cargo install has the advantage of caching the build in the user .cargo directory,
 # so likely the rebuild will be very cheap even after deleting the build directory.
@@ -18,7 +29,7 @@ execute_process(
         --root "${generator_destination}"
         --locked
         ${_CORROSION_QUIET_OUTPUT_FLAG}
-        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+        WORKING_DIRECTORY "${generator_src}"
         RESULT_VARIABLE generator_build_failed
 )
 if(generator_build_failed)
@@ -30,9 +41,16 @@ set(host_executable_suffix "")
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
     set(host_executable_suffix ".exe")
 endif()
+
 set(_CORROSION_GENERATOR_EXE
         "${generator_destination}/bin/corrosion-generator${host_executable_suffix}"
-        PARENT_SCOPE)
+)
+
+add_executable(Corrosion::Generator IMPORTED GLOBAL)
+set_property(
+        TARGET Corrosion::Generator
+        PROPERTY IMPORTED_LOCATION "${_CORROSION_GENERATOR_EXE}")
+
 if (CORROSION_DEV_MODE)
     # If you're developing Corrosion, you want to make sure to re-configure whenever the
     # generator changes.

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -1,0 +1,46 @@
+message(STATUS "Building CMake Generator for Corrosion - This may take a while")
+
+set(generator_destination "${CMAKE_CURRENT_BINARY_DIR}/legacy_generator_src")
+set(generator_destination "${CMAKE_CURRENT_BINARY_DIR}/legacy_generator")
+set(generator_build_quiet "")
+
+# Using cargo install has the advantage of caching the build in the user .cargo directory,
+# so likely the rebuild will be very cheap even after deleting the build directory.
+execute_process(
+        COMMAND ${CMAKE_COMMAND}
+        -E env
+        # If the Generator is built at configure of a project (instead of being pre-installed)
+        # We don't want environment variables like `RUSTFLAGS` affecting the Generator build.
+        --unset=RUSTFLAGS
+        "CARGO_BUILD_RUSTC=${RUSTC_EXECUTABLE}"
+        "${CARGO_EXECUTABLE}" install
+        --path "."
+        --root "${generator_destination}"
+        --locked
+        ${_CORROSION_QUIET_OUTPUT_FLAG}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+        RESULT_VARIABLE generator_build_failed
+)
+if(generator_build_failed)
+    message(FATAL_ERROR "Building CMake Generator for Corrosion - failed")
+else()
+    message(STATUS "Building CMake Generator for Corrosion - done")
+endif()
+set(host_executable_suffix "")
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    set(host_executable_suffix ".exe")
+endif()
+set(_CORROSION_GENERATOR_EXE
+        "${generator_destination}/bin/corrosion-generator${host_executable_suffix}"
+        PARENT_SCOPE)
+if (CORROSION_DEV_MODE)
+    # If you're developing Corrosion, you want to make sure to re-configure whenever the
+    # generator changes.
+    file(GLOB_RECURSE _RUST_FILES CONFIGURE_DEPENDS generator/src/*.rs)
+    file(GLOB _CARGO_FILES CONFIGURE_DEPENDS generator/Cargo.*)
+    set_property(
+            DIRECTORY APPEND
+            PROPERTY CMAKE_CONFIGURE_DEPENDS
+            ${_RUST_FILES} ${_CARGO_FILES})
+endif()
+

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -7,13 +7,6 @@ edition = "2018"
 
 [dependencies]
 cargo_metadata = "0.15"
-# The crates below are indirect dependencies of cargo metadata,
-# We explicitly specify maximum versions to allow building the generator
-# with older toolchains.
-# Version 1.0.157 upgrades to syn 2.0 and raises MSRV to 1.56
-serde = { version = ">=1, <1.0.157", default-features=false }
-# Version 1.0.40 upgrades to syn 2.0 and raises MSRV to 1.56
-thiserror = { version = ">=1, <1.0.40", default-features=false }
 
 [dependencies.clap]
 version = "2.34"

--- a/generator/Compat.Cargo.lock
+++ b/generator/Compat.Cargo.lock
@@ -10,27 +10,27 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -57,61 +57,63 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata",
  "clap",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.182"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb30a74471f5b7a1fa299f40b4bf1be93af61116df95465b2b5fc419331e430"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.182"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4c2c6ea4bc09b5c419012eafcdb0fcef1d9119d626c8f3a0708a5b92d38a70"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -120,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -131,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -151,18 +153,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -171,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-width"

--- a/generator/Compat.Cargo.toml
+++ b/generator/Compat.Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "corrosion-generator"
+version = "0.1.0"
+authors = ["Andrew Gaspar <andrew.gaspar@outlook.com>"]
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+cargo_metadata = "0.15"
+# The crates below are indirect dependencies of cargo metadata,
+# We explicitly specify maximum versions to allow building the generator
+# with older toolchains.
+# Version 1.0.157 upgrades to syn 2.0 and raises MSRV to 1.56
+serde = { version = ">=1, <1.0.157", default-features=false }
+# Version 1.0.40 upgrades to syn 2.0 and raises MSRV to 1.56
+thiserror = { version = ">=1, <1.0.40", default-features=false }
+
+[dependencies.clap]
+version = "2.34"
+default-features = false
+# Make sure this crate still compiles while it is checked out
+# in a sub-directory of a repository that has a Cargo.toml.
+[workspace]


### PR DESCRIPTION
- Reproduce issue 428 by testing the legacy Generator + nightly Rust in CI.
- Refactor the CMake code for building the legacy Generator into a subdirectory
- Select a Cargo.toml / Cargo.lock for the legacy Generator depending on the Rust version