### PR TITLE
Fix support for hostbuild executables when cross-compiling to non-windows on windows hosts

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -129,6 +129,22 @@ function(_corrosion_set_imported_location_legacy target_name base_property filen
         )
 endfunction()
 
+
+# Sets out_var to true if the byproduct copying and imported location is done in a deferred
+# manner to respect target properties, etc. that may be set later.
+function(_corrosion_determine_deferred_byproduct_copying_and_import_location_handling out_var)
+    set(${out_var} ${CORROSION_RESPECT_OUTPUT_DIRECTORY} PARENT_SCOPE)
+endfunction()
+
+function(_corrosion_bin_target_suffix target_name out_var_suffix)
+    get_target_property(hostbuild "${target_name}" ${_CORR_PROP_HOST_BUILD})
+    if(hostbuild AND CMAKE_HOST_WIN32)
+        set(${out_var_suffix} ".exe" PARENT_SCOPE)
+    elseif(Rust_CARGO_TARGET_OS STREQUAL "windows")
+        set(${out_var_suffix} ".exe" PARENT_SCOPE)
+    endif()
+endfunction()
+
 # Do not call this function directly!
 #
 # This function should be called deferred to evaluate target properties late in the configure stage.
@@ -142,6 +158,16 @@ function(_corrosion_set_imported_location_deferred target_name base_property out
         set(output_dir_prop_target_name "${CMAKE_MATCH_1}")
     else()
         set(output_dir_prop_target_name "${target_name}")
+    endif()
+
+    # Append .exe suffix for executable by-products if the target is windows or if it's a host
+    # build and the host is Windows.
+    get_target_property(target_type ${target_name} TYPE)
+    if(${target_type} STREQUAL "EXECUTABLE")
+        _corrosion_bin_target_suffix(${target_name} "suffix")
+        if(suffix)
+            set(filename "${filename}${suffix}")
+        endif()
     endif()
 
     get_target_property(output_directory "${output_dir_prop_target_name}" "${output_directory_property}")
@@ -220,7 +246,8 @@ endfunction()
 #    artifact.
 # - filename of the artifact.
 function(_corrosion_set_imported_location target_name base_property output_directory_property filename)
-    if(CORROSION_RESPECT_OUTPUT_DIRECTORY)
+    _corrosion_determine_deferred_byproduct_copying_and_import_location_handling("defer")
+    if(defer)
         _corrosion_call_set_imported_location_deferred("${target_name}" "${base_property}" "${output_directory_property}" "${filename}")
     else()
         _corrosion_set_imported_location_legacy("${target_name}" "${base_property}" "${filename}")
@@ -294,6 +321,17 @@ function(_corrosion_copy_byproduct_deferred target_name output_dir_prop_name car
         endif()
     endif()
 
+    # Append .exe suffix for executable by-products if the target is windows or if it's a host
+    # build and the host is Windows.
+    get_target_property(target_type ${target_name} TYPE)
+    if(${target_type} STREQUAL "EXECUTABLE")
+        _corrosion_bin_target_suffix(${target_name} "suffix")
+        if(suffix)
+            set(tmp_file_names "${file_names}")
+            list(TRANSFORM tmp_file_names APPEND "${suffix}" OUTPUT_VARIABLE file_names)
+        endif()
+    endif()
+
     list(TRANSFORM file_names PREPEND "${cargo_build_dir}/" OUTPUT_VARIABLE src_file_names)
     list(TRANSFORM file_names PREPEND "${output_dir}/" OUTPUT_VARIABLE dst_file_names)
     message(DEBUG "Adding command to copy byproducts `${file_names}` to ${dst_file_names}")
@@ -335,7 +373,8 @@ endfunction()
 # - cargo_build_dir: the directory cargo build places it's output artifacts in.
 # - filenames: the file names of any output artifacts as a list.
 function(_corrosion_copy_byproducts target_name output_dir_prop_name cargo_build_dir filenames)
-    if(CORROSION_RESPECT_OUTPUT_DIRECTORY)
+    _corrosion_determine_deferred_byproduct_copying_and_import_location_handling("defer")
+    if(defer)
         _corrosion_call_copy_byproduct_deferred("${target_name}" "${output_dir_prop_name}" "${cargo_build_dir}" "${filenames}")
     else()
         _corrosion_copy_byproduct_legacy("${target_name}" "${cargo_build_dir}" "${filenames}")
@@ -520,10 +559,15 @@ function(_corrosion_add_bin_target workspace_manifest_path bin_name out_bin_bypr
         set(${out_pdb_byproduct} "${pdb_name}" PARENT_SCOPE)
     endif()
 
-    if(Rust_CARGO_TARGET_OS STREQUAL "windows")
-        set(bin_filename "${bin_name}.exe")
+    set(bin_filename "${bin_name}")
+    _corrosion_determine_deferred_byproduct_copying_and_import_location_handling("defer")
+    if(defer)
+        # .exe suffix will be added later, also depending on possible hostbuild
+        # target property
     else()
-        set(bin_filename "${bin_name}")
+        if(Rust_CARGO_TARGET_OS STREQUAL "windows")
+            set(bin_filename "${bin_name}.exe")
+        endif()
     endif()
     set(${out_bin_byproduct} "${bin_filename}" PARENT_SCOPE)
 

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -283,7 +283,7 @@ function(_corrosion_copy_byproduct_legacy target_name cargo_build_dir file_names
     )
 endfunction()
 
-function(_corrosion_copy_byproduct_deferred target_name output_dir_prop_name cargo_build_dir file_names)
+function(_corrosion_copy_byproduct_deferred target_name output_dir_prop_name cargo_build_dir file_names is_binary)
     if(ARGN)
         message(FATAL_ERROR "Unexpected additional arguments")
     endif()
@@ -323,8 +323,7 @@ function(_corrosion_copy_byproduct_deferred target_name output_dir_prop_name car
 
     # Append .exe suffix for executable by-products if the target is windows or if it's a host
     # build and the host is Windows.
-    get_target_property(target_type ${target_name} TYPE)
-    if(${target_type} STREQUAL "EXECUTABLE")
+    if(${is_binary})
         _corrosion_bin_target_suffix(${target_name} "suffix")
         if(suffix)
             set(tmp_file_names "${file_names}")
@@ -351,7 +350,7 @@ function(_corrosion_copy_byproduct_deferred target_name output_dir_prop_name car
     )
 endfunction()
 
-function(_corrosion_call_copy_byproduct_deferred target_name output_dir_prop_name cargo_build_dir file_names)
+function(_corrosion_call_copy_byproduct_deferred target_name output_dir_prop_name cargo_build_dir file_names is_binary)
     cmake_language(EVAL CODE "
         cmake_language(DEFER
             CALL
@@ -360,6 +359,7 @@ function(_corrosion_call_copy_byproduct_deferred target_name output_dir_prop_nam
             [[${output_dir_prop_name}]]
             [[${cargo_build_dir}]]
             [[${file_names}]]
+            [[${is_binary}]]
         )
     ")
 endfunction()
@@ -372,10 +372,11 @@ endfunction()
 #   `RUNTIME_OUTPUT_DIRECTORY`)
 # - cargo_build_dir: the directory cargo build places it's output artifacts in.
 # - filenames: the file names of any output artifacts as a list.
-function(_corrosion_copy_byproducts target_name output_dir_prop_name cargo_build_dir filenames)
+# - is_binary: TRUE if the byproducts are program executables.
+function(_corrosion_copy_byproducts target_name output_dir_prop_name cargo_build_dir filenames is_binary)
     _corrosion_determine_deferred_byproduct_copying_and_import_location_handling("defer")
     if(defer)
-        _corrosion_call_copy_byproduct_deferred("${target_name}" "${output_dir_prop_name}" "${cargo_build_dir}" "${filenames}")
+        _corrosion_call_copy_byproduct_deferred("${target_name}" "${output_dir_prop_name}" "${cargo_build_dir}" "${filenames}" "${is_binary}")
     else()
         _corrosion_copy_byproduct_legacy("${target_name}" "${cargo_build_dir}" "${filenames}")
     endif()

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -136,17 +136,17 @@ function(_generator_add_package_targets)
             )
             if(archive_byproducts)
                 _corrosion_copy_byproducts(
-                    ${target_name} ARCHIVE_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${archive_byproducts}"
+                    ${target_name} ARCHIVE_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${archive_byproducts}" FALSE
                 )
             endif()
             if(shared_lib_byproduct)
                 _corrosion_copy_byproducts(
-                    ${target_name} LIBRARY_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${shared_lib_byproduct}"
+                    ${target_name} LIBRARY_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${shared_lib_byproduct}" FALSE
                 )
             endif()
             if(pdb_byproduct)
                 _corrosion_copy_byproducts(
-                    ${target_name} PDB_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${pdb_byproduct}"
+                    ${target_name} PDB_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${pdb_byproduct}" FALSE
                 )
             endif()
             list(APPEND corrosion_targets ${target_name})
@@ -174,11 +174,11 @@ function(_generator_add_package_targets)
                 ${no_linker_override}
             )
             _corrosion_copy_byproducts(
-                    ${target_name} RUNTIME_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${bin_byproduct}"
+                    ${target_name} RUNTIME_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${bin_byproduct}" TRUE
             )
             if(pdb_byproduct)
                 _corrosion_copy_byproducts(
-                        ${target_name} PDB_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${pdb_byproduct}"
+                        ${target_name} PDB_OUTPUT_DIRECTORY "${cargo_build_out_dir}" "${pdb_byproduct}" FALSE
                 )
             endif()
             list(APPEND corrosion_targets ${target_name})


### PR DESCRIPTION
- Defer the determination of whether to apply a .exe suffix for the byproduct copying and imported location setting if possible
- Determine the .exe suffix first based on the existence of the hostbuild property and then fall back Rust_CARGO_TARGET_OS