### PR TITLE
Add "chimera" as a known triple vendor

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -93,6 +93,7 @@ function(_corrosion_parse_target_triple target_triple out_arch out_vendor out_os
         "nvidia"
         "openwrt"
         "alpine"
+        "chimera"
         "unknown"
         "uwp" # aarch64-uwp-windows-msvc
         "wrs" # e.g. aarch64-wrs-vxworks


### PR DESCRIPTION
On [Chimera Linux](https://chimera-linux.org/) the target triple of the packaged Rust compiler is `<arch>-chimera-linux-musl`. This PR adds `chimera` to the known vendors to address this warning:

```
CMake Warning at cmake/FindRust.cmake:113 (message):
  Failed to parse target-triple `x86_64-chimera-linux-musl`.Corrosion
  determines some information about the output artifacts based on OS
  specified in the Rust target-triple.
```