### PR TITLE
Add unikraft to known vendors

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -94,6 +94,7 @@ function(_corrosion_parse_target_triple target_triple out_arch out_vendor out_os
         "openwrt"
         "alpine"
         "chimera"
+        "unikraft"
         "unknown"
         "uwp" # aarch64-uwp-windows-msvc
         "wrs" # e.g. aarch64-wrs-vxworks


### PR DESCRIPTION
`x86_64-unikraft-linux-musl` was added in Rust 1.73