### PR TITLE
fix: add a check to include, default to no change in actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,11 @@ endif()
 #
 # It is strongly encouraged to install Corrosion separately and use
 # `find_package(Corrosion REQUIRED)` instead if that works with your workflow.
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-include(Corrosion)
+option(INCLUDE_CORROSION "Optionally include Corrosion during the CMake Process." ON)
+if (INCLUDE_CORROSION)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+    include(Corrosion)
+endif()
 
 # Testing
 if (CORROSION_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ endif()
 #
 # It is strongly encouraged to install Corrosion separately and use
 # `find_package(Corrosion REQUIRED)` instead if that works with your workflow.
-option(INCLUDE_CORROSION "Optionally include Corrosion during the CMake Process." ON)
-if (INCLUDE_CORROSION)
+option(CORROSION_INSTALL_ONLY "Only add rules for installing Corrosion itself." OFF)
+if (NOT CORROSION_INSTALL_ONLY)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
     include(Corrosion)
 endif()


### PR DESCRIPTION
While creating the Vcpkg port, I discovered that the CMake script tries to include the tool during the build process immediately after a note recommending that users **not** do this. To create the Vcpkg port, I cannot have Rust available. To resolve this, I need to optionally disable the include as it is recommended.