### PR TITLE
CI: Update actions to use node20

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -33,10 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: ${{ inputs.cmake }}
-          ninja: 1.10.0
+          cmakeVersion: "${{ inputs.cmake }}"
+          ninjaVersion: "~1.10.0"
       - name: Install Rust
         id: install_rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,10 +83,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: ${{ matrix.cmake }}
-          ninja: 1.10.0
+          cmakeVersion: "${{ matrix.cmake }}"
+          ninjaVersion: "~1.10.0"
       - name: Install Rust
         id: install_rust
         uses: dtolnay/rust-toolchain@master
@@ -127,10 +127,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: ${{ matrix.cmake }}
-          ninja: 1.10.0
+          cmakeVersion: "${{ matrix.cmake }}"
+          ninjaVersion: "~1.10.0"
       - name: Install Rust
         id: install_rust
         uses: dtolnay/rust-toolchain@master
@@ -151,10 +151,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: 3.22.6
-          ninja: 1.10.0
+          cmakeVersion: "~3.22.0"
+          ninjaVersion: "~1.10.0"
       - name: Install Rust
         id: install_rust
         uses: dtolnay/rust-toolchain@master
@@ -232,10 +232,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: ${{ matrix.cmake }}
-          ninja: 1.10.0
+          cmakeVersion: "${{ matrix.cmake }}"
+          ninjaVersion: "~1.10.0"
       # Install cbindgen before Rust to use recent default Rust version.
       - name: Install cbindgen
         run: cargo install cbindgen
@@ -283,10 +283,10 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: 3.22.6
-          ninja: 1.10.0
+          cmakeVersion: "~3.22.0"
+          ninjaVersion: "~1.10.0"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -322,10 +322,10 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: 3.22.6
-          ninja: 1.10.0
+          cmakeVersion: "~3.22.0"
+          ninjaVersion: "~1.10.0"
       # Install cbindgen before Rust to use recent default Rust version.
       - name: Install cbindgen
         run: cargo install cbindgen

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -268,7 +268,7 @@ jobs:
           - cxxbridge_version: "1.0.86"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache_cxxbridge
         with:
           path: "~/.cargo/bin/cxxbridge*"

--- a/.github/workflows/visual_studio.yaml
+++ b/.github/workflows/visual_studio.yaml
@@ -27,10 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: ${{ inputs.cmake }}
-          ninja: 1.10.0
+          cmakeVersion: "${{ inputs.cmake }}"
+          ninjaVersion: "~1.10.0"
       - name: Install Rust
         id: install_rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/visual_studio.yaml
+++ b/.github/workflows/visual_studio.yaml
@@ -42,7 +42,7 @@ jobs:
       # significantly faster.
       - name: Cache MSVC build directory
         id: cache-msvc-builddir
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build
           key: ${{ inputs.os }}-${{ inputs.target_arch }}-${{ inputs.rust }}-msvc-${{ inputs.vs_version}}-build


### PR DESCRIPTION
- bump actions/cache to v4
- Use lukka/get-cmake instead of corrosion-rs/install-cmake. This fixes deprecation warnings in CI due to
the deprecation of node16.