### PR TITLE
Set `_CORROSION_VERBOSE_OUTPUT_FLAG` as cache entry

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -511,10 +511,10 @@ include(CorrosionGenerator)
 # Note: `cmake_language(GET_MESSAGE_LOG_LEVEL <output_variable>)` requires CMake 3.25,
 # so we offer our own option to control verbosity of downstream commands (e.g. cargo build)
 if (CORROSION_VERBOSE_OUTPUT)
-    set(_CORROSION_VERBOSE_OUTPUT_FLAG --verbose)
+    set(_CORROSION_VERBOSE_OUTPUT_FLAG --verbose CACHE INTERNAL "")
 else()
     # We want to silence some less important commands by default.
-    set(_CORROSION_QUIET_OUTPUT_FLAG --quiet)
+    set(_CORROSION_QUIET_OUTPUT_FLAG --quiet CACHE INTERNAL "")
 endif()
 
 set(_CORROSION_CARGO_VERSION ${Rust_CARGO_VERSION} CACHE INTERNAL "cargo version used by corrosion")

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -511,10 +511,10 @@ include(CorrosionGenerator)
 # Note: `cmake_language(GET_MESSAGE_LOG_LEVEL <output_variable>)` requires CMake 3.25,
 # so we offer our own option to control verbosity of downstream commands (e.g. cargo build)
 if (CORROSION_VERBOSE_OUTPUT)
-    set(_CORROSION_VERBOSE_OUTPUT_FLAG --verbose CACHE INTERNAL "")
+    set(_CORROSION_VERBOSE_OUTPUT_FLAG --verbose CACHE INTERNAL "" FORCE)
 else()
     # We want to silence some less important commands by default.
-    set(_CORROSION_QUIET_OUTPUT_FLAG --quiet CACHE INTERNAL "")
+    set(_CORROSION_QUIET_OUTPUT_FLAG --quiet CACHE INTERNAL "" FORCE)
 endif()
 
 set(_CORROSION_CARGO_VERSION ${Rust_CARGO_VERSION} CACHE INTERNAL "cargo version used by corrosion")

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -511,10 +511,10 @@ include(CorrosionGenerator)
 # Note: `cmake_language(GET_MESSAGE_LOG_LEVEL <output_variable>)` requires CMake 3.25,
 # so we offer our own option to control verbosity of downstream commands (e.g. cargo build)
 if (CORROSION_VERBOSE_OUTPUT)
-    set(_CORROSION_VERBOSE_OUTPUT_FLAG --verbose CACHE INTERNAL "" FORCE)
+    set(_CORROSION_VERBOSE_OUTPUT_FLAG --verbose CACHE INTERNAL "")
 else()
     # We want to silence some less important commands by default.
-    set(_CORROSION_QUIET_OUTPUT_FLAG --quiet CACHE INTERNAL "" FORCE)
+    set(_CORROSION_QUIET_OUTPUT_FLAG --quiet CACHE INTERNAL "")
 endif()
 
 set(_CORROSION_CARGO_VERSION ${Rust_CARGO_VERSION} CACHE INTERNAL "cargo version used by corrosion")


### PR DESCRIPTION
The value of the `_CORROSION_VERBOSE_OUTPUT_FLAG` variable (set based on the `CORROSION_VERBOSE_OUTPUT` option) isn't propagated to the `_add_cargo_build` function where it is used: https://github.com/corrosion-rs/corrosion/blob/0a3bdf452995803c334d79dc9a2affbfad51b720/cmake/Corrosion.cmake#L768 Setting it as cache entry fixes that.