### PR TITLE
corrosion_import_crate: Fix PROFILE argument in combination with CRATES

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -934,7 +934,6 @@ function(corrosion_import_crate)
             imported_crates
         ${crate_allowlist}
         ${crate_types}
-        ${cargo_profile}
         ${no_linker_override}
     )
 

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -894,7 +894,6 @@ function(corrosion_import_crate)
     _corrosion_option_passthrough_helper(FROZEN COR frozen)
     _corrosion_arg_passthrough_helper(CRATES COR crate_allowlist)
     _corrosion_arg_passthrough_helper(CRATE_TYPES COR crate_types)
-    _corrosion_arg_passthrough_helper(PROFILE COR cargo_profile)
 
     if(COR_PROFILE)
         if(Rust_VERSION VERSION_LESS 1.57.0)


### PR DESCRIPTION
Do not forward the PROFILE argument from `corrosion_import_crate` to `_generator_add_cargo_targets`.

Closes #495.