### PR TITLE
ci: bump actions to avoid deprecation notice

### DIFF
--- a/.github/actions/setup_test/action.yaml
+++ b/.github/actions/setup_test/action.yaml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Cache Cargo registry
       id: cache-registry
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry
@@ -138,10 +138,10 @@ runs:
         arch: ${{ steps.arch_flags.outputs.msvc }}
       if: ${{ 'msvc' == steps.determine_abi.outputs.abi }}
     - name: Install CMake
-      uses: corrosion-rs/install-cmake@v2
+      uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
       with:
-        cmake: ${{inputs.cmake}}
-        ninja: 1.10.0
+        cmakeVersion: "${{ inputs.cmake }}"
+        ninjaVersion: "~1.10.0"
     - name: Install Rust
       id: install_rust
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -24,7 +24,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Install mdbook
@@ -39,7 +39,7 @@ jobs:
           cd doc
           mdbook build
       # Override mdbooks default highlight.js with a custom version containing CMake support.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'highlightjs/highlight.js'
           # mdbook currently (as of v0.4.27) does not support v11 yet.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
     name: Test MSRV of the new lockfile
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         id: install_rust
         uses: dtolnay/rust-toolchain@1.56
@@ -164,7 +164,7 @@ jobs:
             abi: gnu
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Environment and Configure CMake
         uses: "./.github/actions/setup_test"
         with:
@@ -204,13 +204,13 @@ jobs:
             cmake: 3.21.5 # VS on windows-2022 requires at least CMake 3.21
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # The initial configure for MSVC is quite slow, so we cache the build directory
       # (including the build directories of the tests) since reconfiguring is
       # significantly faster.
       - name: Cache MSVC build directory
         id: cache-msvc-builddir
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build
           key: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.rust }}-msvc-build
@@ -243,8 +243,8 @@ jobs:
         #  - os: windows-2019
         #    abi: gnu
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: cache_cxxbridge
         with:
           path: "~/.cargo/bin/cxxbridge*"
@@ -283,15 +283,15 @@ jobs:
           - os: macos-12
             rust: 1.54.0  # On MacOS-12 linking fails before Rust 1.54
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup MSVC Development Environment
         uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
       - name: Install CMake
-        uses: corrosion-rs/install-cmake@v2
+        uses: lukka/get-cmake@519de0c7b4812477d74976b2523a9417f552d126
         with:
-          cmake: 3.18.0
-          ninja: 1.10.0
+          cmakeVersion: "~3.18.0"
+          ninjaVersion: "~1.10.0"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/test_legacy.yaml
+++ b/.github/workflows/test_legacy.yaml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Legacy Generator
         id: cache_generator
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{github.workspace}}/corrosion-prebuilt-generator
           key: ${{ runner.os }}-${{ inputs.rust }}-generator-${{ hashFiles('generator/src/**', 'generator/Cargo.toml', 'generator/Cargo.lock') }}


### PR DESCRIPTION
applies changes from 6e2740fb3d817bb0422a579ac542471f59af7cfb and 366066c9caed822a4cbfc2fafbf7d0116d59b832
to the stable/v0.4 branch.