### PR TITLE
cbindgen: Pass Rust target-triple to cbindgen

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,9 @@
 - If `corrosion_link_libraries()` is called on a Rust static library target, then
   `target_link_libraries()` is called to propogate the dependencies to C/C++ consumers.
   Previously a warning was emitted in this case and the arguments ignored. [#506]
+- `corrosion_experimental_cbindgen()` can now be called multiple times on the same Rust target,
+  as long as the output header name differs. This may be useful to generate separate C and C++
+  bindings. [#507]
 
 ### Fixes
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,16 +12,20 @@
 - Support using the `$<CONFIG>` generator expression in `OUTPUT_DIRECTORY`. [#459]
 - If `corrosion_link_libraries()` is called on a Rust static library target, then
   `target_link_libraries()` is called to propogate the dependencies to C/C++ consumers.
-  Previously a warning was emitted in this case and the arguments ignored.
+  Previously a warning was emitted in this case and the arguments ignored. [#506]
 
 ### Fixes
 
 - Combine `-framework` flags on macos to avoid linker deduplication errors [#455]
 - Set the `AR_<triple>` variable for `cc-rs` (except for msvc targets) [#456]
+- `corrosion_experimental_cbindgen()` now forwards the Rust target-triple (e.g. `aarch64-unknown-linux-gnu`)
+  to cbindgen via the `TARGET` environment variable. The `hostbuild` property is considered. [#507]
 
 [#459]: https://github.com/corrosion-rs/corrosion/pull/459
 [#456]: https://github.com/corrosion-rs/corrosion/pull/456
 [#455]: https://github.com/corrosion-rs/corrosion/pull/455
+[#506]: https://github.com/corrosion-rs/corrosion/pull/506
+[#507]: https://github.com/corrosion-rs/corrosion/pull/507
 
 # v0.4.7 (2024-01-19)
 

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1681,11 +1681,19 @@ function(corrosion_experimental_cbindgen)
         )
     endif()
 
-    add_custom_target(_corrosion_cbindgen_${rust_target}_bindings
-        DEPENDS "${generated_header}"
-        COMMENT "Generate cbindgen bindings for package ${rust_cargo_package}"
+    if(NOT TARGET "_corrosion_cbindgen_${rust_target}_bindings")
+        add_custom_target(_corrosion_cbindgen_${rust_target}_bindings
+                COMMENT "Generate cbindgen bindings for package ${rust_cargo_package}"
+        )
+    endif()
+    # Users might want to call cbindgen multiple times, e.g. to generate separate C++ and C header files.
+    string(MAKE_C_IDENTIFIER "${output_header_name}" header_identifier )
+    add_custom_target("_corrosion_cbindgen_${rust_target}_bindings_${header_identifier}"
+            DEPENDS "${generated_header}"
+            COMMENT "Generate ${generated_header} for ${rust_target}"
     )
-    add_dependencies(${rust_target} _corrosion_cbindgen_${rust_target}_bindings)
+    add_dependencies("_corrosion_cbindgen_${rust_target}_bindings" "_corrosion_cbindgen_${rust_target}_bindings_${header_identifier}")
+    add_dependencies(${rust_target} "_corrosion_cbindgen_${rust_target}_bindings")
 endfunction()
 
 # Parse the version of a Rust package from it's package manifest (Cargo.toml)


### PR DESCRIPTION
- `cbindgen` considers the `TARGET` environment variable when generating bindings, so we should set the target we are compiling for.