### PR TITLE
Improvements to corrosion_link_libraries()

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1077,7 +1077,6 @@ function(corrosion_link_libraries target_name)
             " aside from establishing a build dependency."
             )
     endif()
-    add_dependencies(_cargo-build_${target_name} ${ARGN})
     foreach(library ${ARGN})
         set_property(
             TARGET _cargo-build_${target_name}
@@ -1086,8 +1085,29 @@ function(corrosion_link_libraries target_name)
             $<TARGET_PROPERTY:${library},LINKER_LANGUAGE>
         )
 
-        corrosion_add_target_local_rustflags(${target_name} "-L$<TARGET_LINKER_FILE_DIR:${library}>")
-        corrosion_add_target_local_rustflags(${target_name} "-l$<TARGET_LINKER_FILE_BASE_NAME:${library}>")
+        if (TARGET ${library})
+            corrosion_add_target_local_rustflags(${target_name}
+                "-L$<TARGET_LINKER_FILE_DIR:${library}>"
+                "-l$<TARGET_LINKER_FILE_BASE_NAME:${library}>"
+            )
+            add_dependencies(_cargo-build_${target_name} ${library})
+            get_property(libs TARGET ${library} PROPERTY INTERFACE_LINK_LIBRARIES)
+            corrosion_link_libraries(${target_name} ${libs})
+        elseif(IS_ABSOLUTE ${library})
+            # Linking via full path
+            corrosion_add_target_local_rustflags(${target_name} "-Clink-arg=${library}")
+        else()
+            # We have to assume ${library} is a non-CMake library name
+            corrosion_add_target_local_rustflags(${target_name} "-l${library}")
+        endif()
+
+        # Propagate dependency on ${library}
+        set_property(
+            TARGET _cargo-build_${target_name}
+            APPEND
+            PROPERTY INTERFACE_LINK_LIBRARIES
+            ${library}
+        )
     endforeach()
 endfunction(corrosion_link_libraries)
 


### PR DESCRIPTION
As mentioned in #505,
- Allow linking by full path and non-target library name
- Propagate linking dependencies to artifacts