### PR TITLE
cmake export (find_package) becomes portable

### DIFF
--- a/cmake/CorrosionConfig.cmake.in
+++ b/cmake/CorrosionConfig.cmake.in
@@ -4,6 +4,6 @@ if (Corrosion_FOUND)
     return()
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "@CMAKE_INSTALL_FULL_DATADIR@/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_DATADIR@/cmake")
 
 include(Corrosion)


### PR DESCRIPTION
Description:
Currently the cmake export `CorrosionConfig.cmake` adds a hardcoded path (`CMAKE_INSTALL_FULL_DATADIR`) to `CMAKE_MODULE_PATH`. Unfortunately this path is only valid during build time of corrosion. 
If the resulting package is shipped (e.g. via a package manager like conan), then the path and therefore also the corrosion package becomes invalid. 

Solution:
Instead, the import prefix of the package (`PACKAGE_PREFIX_DIR`) is used.