### PR TITLE
Bump the version number to 1.0-pre-release

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build and deploy the documentation of master and the stable/v0.4 branch
+  # Build and deploy the documentation of master and the stable/v0.5 branch
   deploy:
     runs-on: ubuntu-latest
     environment:
@@ -36,18 +36,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: main
-      - name: Checkout stable/v0.4
+      - name: Checkout stable/v0.5
         uses: actions/checkout@v4
         with:
-          path: stable-v0.4
-          ref: 'stable/v0.4'
+          path: stable-v0.5
+          ref: 'stable/v0.5'
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Build mdbook for main branch
         working-directory: 'main/doc'
         run: mdbook build
-      - name: Build mdbook for stable/v0.4 branch
-        working-directory: 'stable-v0.4/doc'
+      - name: Build mdbook for stable/v0.5 branch
+        working-directory: 'stable-v0.5/doc'
         run: mdbook build
       # Override mdbooks default highlight.js with a custom version containing CMake support.
       - uses: actions/checkout@v4
@@ -66,9 +66,9 @@ jobs:
           cp highlightjs/build/highlight.min.js main/doc/book/highlight.js
           cp highlightjs/build/highlight.min.js stable-v0.4/doc/book/highlight.js
       - name: Copy stable doc into main
-        run: mkdir main/doc/book/v0.4 && cp -a stable-v0.4/doc/book/. main/doc/book/v0.4/
+        run: mkdir main/doc/book/v0.5 && cp -a stable-v0.5/doc/book/. main/doc/book/v0.5/
       - name: Debug print
-        run: ls -la main/doc/book/v0.4
+        run: ls -la main/doc/book/v0.5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Corrosion
     # tagged release. Users don't need to care about this, it is mainly to
     # clearly see in configure logs which version was used, without needing to
     # rely on `git`, since Corrosion may be installed or otherwise packaged.
-    VERSION 0.4.99.99 # a 0.5-pre-release
+    VERSION 0.99.99 # 1.0-pre-release
     LANGUAGES NONE
     HOMEPAGE_URL "https://corrosion-rs.github.io/corrosion/"
 )
@@ -63,7 +63,7 @@ write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/CorrosionConfigVersion.cmake"
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY
-        SameMinorVersion # TODO: Should be SameMajorVersion when 1.0 is released
+        SameMajorVersion
     ARCH_INDEPENDENT
 )
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.4 # Optionally specify a commit hash, version tag or branch here
+    GIT_TAG v0.5 # Optionally specify a commit hash, version tag or branch here
 )
 FetchContent_MakeAvailable(Corrosion)
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ target_link_libraries(your_cpp_bin PUBLIC rust-lib)
 
 ## Requirements
 
-### Stable v0.4 Release
+### Stable v0.5 Release
 
-- CMake 3.15 or newer. Some features may only be available on more recents CMake versions
+- CMake 3.15 or newer. Some features may only be available on more recent CMake versions
 - Rust 1.46 or newer. Some platforms / features may require more recent Rust versions
 
 ### Development (master branch)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,9 +2,6 @@
 
 ### Breaking Changes
 
-- Dashes (`-`) in names of imported CMake **library** targets are now replaced with underscores (`_`).
-  See [issue #501] for details. Users on older Corrosion versions will experience the same
-  change when using Rust 1.79 or newer. `bin` targets are not affected by this change.
 - The master branch of corrosion now requires CMake 3.22. See also the 
   [v0.4.0 Release notes](#040-lts-2023-06-01) for more details.
 - Removed native tooling and the corresponding option `CORROSION_NATIVE_TOOLING`.
@@ -13,31 +10,52 @@
 ### New features
 
 - Support using the `$<CONFIG>` generator expression in `OUTPUT_DIRECTORY`. [#459]
-- If `corrosion_link_libraries()` is called on a Rust static library target, then
-  `target_link_libraries()` is called to propogate the dependencies to C/C++ consumers.
-  Previously a warning was emitted in this case and the arguments ignored. [#506]
+
+
+[#459]: https://github.com/corrosion-rs/corrosion/pull/459
+
+# v0.5.0 (2024-05-11)
+
+### Breaking Changes
+
+- Dashes (`-`) in names of imported CMake **library** targets are now replaced with underscores (`_`).
+  See [issue #501] for details. Users on older Corrosion versions will experience the same
+  change when using Rust 1.79 or newer. `bin` targets are not affected by this change.
+
+[issue #501]: https://github.com/corrosion-rs/corrosion/issues/501
+
+# v0.4.10 (2024-05-11)
+
+### New features
+
 - `corrosion_experimental_cbindgen()` can now be called multiple times on the same Rust target,
   as long as the output header name differs. This may be useful to generate separate C and C++
   bindings. [#507]
+- If `corrosion_link_libraries()` is called on a Rust static library target, then
+  `target_link_libraries()` is called to propagate the dependencies to C/C++ consumers.
+  Previously a warning was emitted in this case and the arguments ignored. [#506]
 
 ### Fixes
 
 - Combine `-framework` flags on macos to avoid linker deduplication errors [#455]
+- `corrosion_experimental_cbindgen()` will now correctly use the package name, instead of assuming that
+  the package and crate name are identical. ([11e27c])
 - Set the `AR_<triple>` variable for `cc-rs` (except for msvc targets) [#456]
+- Fix hostbuild when cross-compiling to windows [#477]
+- Consider vworks executable suffix [#504]
 - `corrosion_experimental_cbindgen()` now forwards the Rust target-triple (e.g. `aarch64-unknown-linux-gnu`)
   to cbindgen via the `TARGET` environment variable. The `hostbuild` property is considered. [#507]
-- Detect msvc linker flags coming from `--print=native-static-libs` and put them into `INTERFACE_LINK_OPTIONS` instead of `INTERFACE_LINK_LIBRARIES` [#511]
-- `corrosion_experimental_cbindgen()` will now correctly use the package name, instead of assuming that 
-  the package and crate name are identical.
+- Fix linking errors with Rust >= 1.79 and `-msvc` targets.` [#511]
 
 
-[issue #501]: https://github.com/corrosion-rs/corrosion/issues/501
-[#459]: https://github.com/corrosion-rs/corrosion/pull/459
-[#456]: https://github.com/corrosion-rs/corrosion/pull/456
 [#455]: https://github.com/corrosion-rs/corrosion/pull/455
+[#456]: https://github.com/corrosion-rs/corrosion/pull/456
+[#477]: https://github.com/corrosion-rs/corrosion/pull/477
+[#504]: https://github.com/corrosion-rs/corrosion/pull/504
 [#506]: https://github.com/corrosion-rs/corrosion/pull/506
 [#507]: https://github.com/corrosion-rs/corrosion/pull/507
 [#511]: https://github.com/corrosion-rs/corrosion/pull/511
+[11e27c]: https://github.com/corrosion-rs/corrosion/pull/514/commits/11e27cde2cf32c7ed539c96eb03c2f10035de538
 
 # v0.4.9 (2024-05-01)
 

--- a/doc/src/introduction.md
+++ b/doc/src/introduction.md
@@ -12,8 +12,8 @@ the rust target.
 
 ## Requirements
 
-- Corrosion supports CMake 3.15 and newer with the v0.4 release. If you are using the v0.4 release, please
-  view [the documentation here](./v0.4/introduction.md)
+- Corrosion supports CMake 3.15 and newer with the v0.5 release. If you are using the v0.5 release, please
+  view [the documentation here](./v0.5/introduction.md)
 - The master branch of Corrosion currently requires CMake 3.22 or newer.
 
 [`target_link_libraries()`]: https://cmake.org/cmake/help/latest/command/target_link_libraries.html

--- a/doc/src/quick_start.md
+++ b/doc/src/quick_start.md
@@ -16,7 +16,7 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.4 # Optionally specify a commit hash, version tag or branch here
+    GIT_TAG v0.5 # Optionally specify a commit hash, version tag or branch here
 )
 # Set any global configuration variables such as `Rust_TOOLCHAIN` before this line!
 FetchContent_MakeAvailable(Corrosion)

--- a/doc/src/setup_corrosion.md
+++ b/doc/src/setup_corrosion.md
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.4 # Optionally specify a commit hash, version tag or branch here
+    GIT_TAG v0.5 # Optionally specify a commit hash, version tag or branch here
 )
 # Set any global configuration variables such as `Rust_TOOLCHAIN` before this line!
 FetchContent_MakeAvailable(Corrosion)


### PR DESCRIPTION
Corrosion changes slowly enough, that I think it makes sense to make an 1.0 release.

CMake doesn't support any modifiers like `-alpha`, so we just take 0.99 instead.
We want to leave room for further breaking releases in the legacy version.