### PR TITLE
Legacy CMake: Respect `CMAKE_<XYZ>_OUTPUT_DIRECTORY`

### DIFF
--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -306,7 +306,7 @@ function(_generator_add_cargo_targets)
     if(GGC_IMPORTED_CRATES)
         set(${GGC_IMPORTED_CRATES} "${created_targets}" PARENT_SCOPE)
     endif()
-
+    # Initialize the `<XYZ>_OUTPUT_DIRECTORY` properties based on `CMAKE_<XYZ>_OUTPUT_DIRECTORY`.
     foreach(target_name ${created_targets})
         foreach(output_var RUNTIME_OUTPUT_DIRECTORY ARCHIVE_OUTPUT_DIRECTORY LIBRARY_OUTPUT_DIRECTORY PDB_OUTPUT_DIRECTORY)
             get_target_property(output_dir ${target_name} "${output_var}")

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -116,6 +116,8 @@ function(_generator_add_package_targets)
             set(shared_lib_byproduct "")
             set(pdb_byproduct "")
 
+            add_library(${target_name} INTERFACE)
+            _corrosion_initialize_properties(${target_name})
             _corrosion_add_library_target(
                 WORKSPACE_MANIFEST_PATH "${workspace_manifest_path}"
                 TARGET_NAME "${target_name}"
@@ -161,6 +163,8 @@ function(_generator_add_package_targets)
         elseif("bin" IN_LIST kinds)
             set(bin_byproduct "")
             set(pdb_byproduct "")
+            add_executable(${target_name} IMPORTED GLOBAL)
+            _corrosion_initialize_properties(${target_name})
             _corrosion_add_bin_target("${workspace_manifest_path}" "${target_name}"
                 "bin_byproduct" "pdb_byproduct"
             )
@@ -306,21 +310,4 @@ function(_generator_add_cargo_targets)
     if(GGC_IMPORTED_CRATES)
         set(${GGC_IMPORTED_CRATES} "${created_targets}" PARENT_SCOPE)
     endif()
-    # Initialize the `<XYZ>_OUTPUT_DIRECTORY` properties based on `CMAKE_<XYZ>_OUTPUT_DIRECTORY`.
-    foreach(target_name ${created_targets})
-        foreach(output_var RUNTIME_OUTPUT_DIRECTORY ARCHIVE_OUTPUT_DIRECTORY LIBRARY_OUTPUT_DIRECTORY PDB_OUTPUT_DIRECTORY)
-            get_target_property(output_dir ${target_name} "${output_var}")
-            if (NOT output_dir AND DEFINED "CMAKE_${output_var}")
-                set_property(TARGET ${target_name} PROPERTY ${output_var} "${CMAKE_${output_var}}")
-            endif()
-
-            foreach(config_type ${CMAKE_CONFIGURATION_TYPES})
-                string(TOUPPER "${config_type}" config_type_upper)
-                get_target_property(output_dir ${target_name} "${output_var}_${config_type_upper}")
-                if (NOT output_dir AND DEFINED "CMAKE_${output_var}_${config_type_upper}")
-                    set_property(TARGET ${target_name} PROPERTY "${output_var}_${config_type_upper}" "${CMAKE_${output_var}_${config_type_upper}}")
-                endif()
-            endforeach()
-        endforeach()
-    endforeach()
 endfunction()

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -134,6 +134,8 @@ impl CargoTarget {
                 writeln!(
                     out_file,
                     "
+                    add_library({target_name} INTERFACE)
+                    _corrosion_initialize_properties({target_name})
                     _corrosion_add_library_target(
                             WORKSPACE_MANIFEST_PATH \"{workspace_manifest_path}\"
                             TARGET_NAME \"{target_name}\"
@@ -157,6 +159,8 @@ impl CargoTarget {
                 writeln!(
                     out_file,
                     "
+                    add_executable({target_name} IMPORTED GLOBAL)
+                    _corrosion_initialize_properties({target_name})
                     _corrosion_add_bin_target(\"{workspace_manifest_path}\" \"{target_name}\"
                         bin_byproduct pdb_byproduct
                     )

--- a/generator/src/subcommands/gen_cmake/target.rs
+++ b/generator/src/subcommands/gen_cmake/target.rs
@@ -189,22 +189,22 @@ impl CargoTarget {
 
             if(archive_byproducts)
                 _corrosion_copy_byproducts(
-                    {target_name} ARCHIVE_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{archive_byproducts}}\" FALSE
+                    {target_name} INTERFACE_ARCHIVE_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{archive_byproducts}}\" FALSE
                 )
             endif()
             if(shared_lib_byproduct)
                 _corrosion_copy_byproducts(
-                    {target_name} LIBRARY_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{shared_lib_byproduct}}\" FALSE
+                    {target_name} INTERFACE_LIBRARY_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{shared_lib_byproduct}}\" FALSE
                 )
             endif()
             if(pdb_byproduct)
                 _corrosion_copy_byproducts(
-                    {target_name} PDB_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{pdb_byproduct}}\" FALSE
+                    {target_name} INTERFACE_PDB_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{pdb_byproduct}}\" FALSE
                 )
             endif()
             if(bin_byproduct)
                 _corrosion_copy_byproducts(
-                    {target_name} RUNTIME_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{bin_byproduct}}\" TRUE
+                    {target_name} INTERFACE_RUNTIME_OUTPUT_DIRECTORY \"${{cargo_build_out_dir}}\" \"${{bin_byproduct}}\" TRUE
                 )
             endif()
             set_property(TARGET {target_name} PROPERTY INTERFACE_COR_CARGO_PACKAGE_NAME {package_name} )

--- a/test/output directory/CMakeLists.txt
+++ b/test/output directory/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(CMAKE_VERSION VERSION_LESS 3.19.0)
-    return()
-endif()
-
 if(CMAKE_C_COMPILER)
     set(TEST_C_COMPILER "C_COMPILER" "${CMAKE_C_COMPILER}")
 endif()
@@ -33,7 +29,12 @@ if(CORROSION_TESTS_INSTALL_CORROSION)
     set_tests_properties("output_directory_build" PROPERTIES FIXTURES_REQUIRED "fixture_corrosion_install")
 endif()
 
-foreach(output_approach targetprop var)
+set(test_variants "var")
+if(NOT CORROSION_NATIVE_TOOLING)
+    list(APPEND test_variants "targetprop")
+endif()
+
+foreach(output_approach ${test_variants})
     if(output_approach STREQUAL "targetprop")
        set(rust_proj_suffix "1")
     elseif(output_approach STREQUAL "var")
@@ -128,13 +129,15 @@ foreach(output_approach targetprop var)
 
 endforeach()
 
-add_test(NAME postbuild_custom_command
-    COMMAND
-    "${CMAKE_COMMAND}"
-    -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/build/another_dir/moved_bin"
-    )
-set_tests_properties("postbuild_custom_command" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
+if(NOT CORROSION_NATIVE_TOOLING)
+    add_test(NAME postbuild_custom_command
+        COMMAND
+        "${CMAKE_COMMAND}"
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/TestFileExists.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/build/another_dir/moved_bin"
+        )
+    set_tests_properties("postbuild_custom_command" PROPERTIES FIXTURES_REQUIRED "build_fixture_output_directory")
+endif()
 
 add_test(NAME "output_directory_cleanup" COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/build")
 set_tests_properties("output_directory_cleanup" PROPERTIES FIXTURES_CLEANUP "build_fixture_output_directory")

--- a/test/output directory/output directory/CMakeLists.txt
+++ b/test/output directory/output directory/CMakeLists.txt
@@ -2,29 +2,32 @@ cmake_minimum_required(VERSION 3.15)
 project(test_project VERSION 0.1.0)
 include(../../test_header.cmake)
 
-corrosion_import_crate(MANIFEST_PATH proj1/Cargo.toml)
+if(NOT CORROSION_NATIVE_TOOLING)
+    corrosion_import_crate(MANIFEST_PATH proj1/Cargo.toml)
 
-# Note: The output directories defined here must be manually kept in sync with the expected test location.
-set_target_properties(rust_bin1
-    PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_bin_targetprop"
-        PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_bin_pdb_targetprop"
+    # Note: The output directories defined here must be manually kept in sync with the expected test location.
+    set_target_properties(rust_bin1
+        PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_bin_targetprop"
+            PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_bin_pdb_targetprop"
 
-)
-set_target_properties(rust_lib1 PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_archive_targetprop")
-set_target_properties(rust_lib1
-    PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_lib_targetprop"
-        PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_lib_pdb_targetprop"
-)
-
-add_custom_command(TARGET cargo-build_rust_bin1 POST_BUILD
-    COMMAND
-    ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/another_dir"
-    COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_PROPERTY:rust_bin1,LOCATION>" "${CMAKE_CURRENT_BINARY_DIR}/another_dir/moved_bin"
+    )
+    set_target_properties(rust_lib1 PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_archive_targetprop")
+    set_target_properties(rust_lib1
+        PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_lib_targetprop"
+            PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_lib_pdb_targetprop"
     )
 
+    add_custom_command(TARGET cargo-build_rust_bin1 POST_BUILD
+        COMMAND
+        ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/another_dir"
+        COMMAND
+        ${CMAKE_COMMAND} -E copy_if_different
+                       "$<TARGET_PROPERTY:rust_bin1,LOCATION>"
+                       "${CMAKE_CURRENT_BINARY_DIR}/another_dir/moved_bin"
+        )
+endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_bin_var")
 set(CMAKE_PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_binlib_pdb_var")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/custom_archive_var")
@@ -39,6 +42,6 @@ unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_PDB_OUTPUT_DIRECTORY)
 
 add_executable(consumer consumer.cpp)
-add_dependencies(consumer cargo-build_rust_lib1 cargo-build_rust_lib2)
+add_dependencies(consumer cargo-build_rust_lib2)
 
-target_link_libraries(consumer rust_lib1 rust_lib2)
+target_link_libraries(consumer rust_lib2)


### PR DESCRIPTION
Make a best effort with old CMake versions to respect output directories. We can't know which properties the user might set or change **after** the crates are imported, but we can respect the `CMAKE_<XYZ>` variables which are set **before** the crates are imported.