### PR TITLE
Backport: Fix FindRust setting Rust_Found=false in wrong scope

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -17,15 +17,14 @@ include(FindPackageHandleStandardArgs)
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "FindRust")
 
-# Print error message and return.
+# Print error message and return. Should not be used from inside functions
 macro(_findrust_failed)
     if("${Rust_FIND_REQUIRED}")
         message(FATAL_ERROR ${ARGN})
     elseif(NOT "${Rust_FIND_QUIETLY}")
         message(WARNING ${ARGN})
     endif()
-    # Note: PARENT_SCOPE is the scope of the caller of the caller of this macro.
-    set(Rust_FOUND "" PARENT_SCOPE)
+    set(Rust_FOUND "")
     return()
 endmacro()
 


### PR DESCRIPTION
The macro _find_rust_failed is not called from inside any functions in FindRust. Find modules are `include`d, so variables need to be set in local scope (which was already done in the successfull case).

Fixes #527

(cherry picked from commit 58d83f0c21c3dcde39ce60079ba5d901aafe7acc)