### PR TITLE
Add support for generic lib crates

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -932,7 +932,7 @@ function(corrosion_import_crate)
         list(APPEND additional_cargo_flags  "--frozen")
     endif()
 
-    if(("lib" IN_LIST COR_CRATE_TYPES))
+    if("lib" IN_LIST COR_CRATE_TYPES)
         # LIB_OVERRIDE must be set to one of these values
         set(valid_lib_overrides "cdylib" "staticlib")
 

--- a/test/output directory/CMakeLists.txt
+++ b/test/output directory/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(configure_cmake_args)
+set(configure_cmake_args "")
 if(CMAKE_C_COMPILER)
     list(APPEND configure_cmake_args "C_COMPILER" "${CMAKE_C_COMPILER}")
 endif()
@@ -150,5 +150,3 @@ set_tests_properties("postbuild_custom_command" PROPERTIES FIXTURES_REQUIRED "bu
 
 add_test(NAME "output_directory_cleanup" COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/build")
 set_tests_properties("output_directory_cleanup" PROPERTIES FIXTURES_CLEANUP "build_fixture_output_directory")
-
-


### PR DESCRIPTION
This is a basic change to add support for generic `lib` crates. According to the Rust [documentation](https://doc.rust-lang.org/reference/linkage.html), the compiler would normally decide what kind of output to generate. However, for Corrosion, it makes sense to allow these crates to be compiled as static or dynamic libraries.

Via the new (optional) parameter `LIB_OVERRIDE` of `corrosion_import_crate`, the user may specify whether they want `lib` crates to be compiled as `cdylib` or `staticlib` crates instead. This only happens when `lib` is actually specified in parameter `CRATE_TYPES`. Internally, a slight modification of the flags passed to cargo-rustc was necessary (`--crate-type=<types...>` is explicitly added after the filter `--lib`). Aside from some minor code cleanup, the core build process remains the same, though.

There is non-zero chance I broke something while implementing this, and my testing scope was rather limited. So please, consider adding this to be main project, but only after thorough review and more testing.