### PR TITLE
Leave choosing `msvcrt` up to the C/C++ CMake code

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -190,7 +190,7 @@ function(_corrosion_determine_libs_new target_triple out_libs out_flags)
             # We leave it up to the C/C++ executable that links in the Rust static-library
             # to determine which version of the msvc runtime library it should select.
             list(FILTER libs_list EXCLUDE REGEX "^msvcrtd?")
-            list(FILTER flags_list EXCLUDE REGEX "^/defaultlib:msvcrtd?")
+            list(FILTER flag_list EXCLUDE REGEX "^/defaultlib:msvcrtd?")
         else()
             message(DEBUG "Determining required native libraries - failed: Regex match failure.")
             message(DEBUG "`native-static-libs` not found in: `${cargo_build_error_message}`")

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -187,8 +187,10 @@ function(_corrosion_determine_libs_new target_triple out_libs out_flags)
                 endif()
             endforeach()
             set(libs_list "${stripped_lib_list}")
-            # Special case `msvcrt` to link with the debug version in Debug mode.
-            list(TRANSFORM libs_list REPLACE "^msvcrt$" "\$<\$<CONFIG:Debug>:msvcrtd>")
+            # We leave it up to the C/C++ executable that links in the Rust static-library
+            # to determine which version of the msvc runtime library it should select.
+            list(FILTER libs_list EXCLUDE REGEX "^msvcrtd?")
+            list(FILTER flags_list EXCLUDE REGEX "^/defaultlib:msvcrtd?")
         else()
             message(DEBUG "Determining required native libraries - failed: Regex match failure.")
             message(DEBUG "`native-static-libs` not found in: `${cargo_build_error_message}`")


### PR DESCRIPTION
It's difficult for Corrosion to correctly choose the right msvcrt version. CMake has a target property for it, and we also don't know which build configurations the user CMake code expectes to be Debug related.

The previous code actually already removed the linking against `msvcrt` in all cases except "Debug" builds. This was not intentional, but indicates that removing the library entirely from the link list, and leaving it up to the C/C++ code to link it in, should work well in practice.