### PR TITLE
Make corrosion_install work for library files and update docs

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1106,11 +1106,9 @@ corrosion_install(TARGETS <target1> ... <targetN>
                   ] [...])
 ```
 * **TARGETS**: Target or targets to install.
-* **EXPORT**: NOT IMPLEMENTED.
-
-TODO: The `ARCHIVE`/`LIBRARY`/... nonsense works like `<artifact-kind> <artifact-option>...` from [`install(TARGETS)`].
-
-[`install(TARGETS)`]: https://cmake.org/cmake/help/latest/command/install.html#targets
+* **ARCHIVE**/**LIBRARY**/**RUNTIME**: Designates that the following settings only apply to that specific type of object.
+* **DESTINATION**: The subdirectory within the CMAKE_INSTALL_PREFIX that a specific object should be placed. Defaults to values from GNUInstallDirs.
+* **PERMISSIONS**: The permissions of files copied into the install prefix.
 
 ANCHOR_END: corrosion-install
 #]=======================================================================]

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1094,9 +1094,12 @@ endfunction()
 
 #[=======================================================================[.md:
 ANCHOR: corrosion-install
+** EXPERIMENTAL **: This function is currently still considered experimental
+  and is not officially released yet. Feedback and Suggestions are welcome.
+
 ```cmake
-corrosion_install(TARGETS <target1> ... <targetN> [EXPORT <export-name>]
-                  [[ARCHIVE|LIBRARY|RUNTIME|PRIVATE_HEADER|PUBLIC_HEADER]
+corrosion_install(TARGETS <target1> ... <targetN>
+                  [[ARCHIVE|LIBRARY|RUNTIME]
                    [DESTINATION <dir>]
                    [PERMISSIONS <permissions...>]
                    [CONFIGURATIONS [Debug|Release|<other-configuration>]]
@@ -1272,10 +1275,7 @@ function(corrosion_install)
                     elseif (DEFINED COR_INSTALL_DEFAULT_PERMISSIONS)
                         set(PERMISSIONS ${COR_INSTALL_DEFAULT_PERMISSIONS})
                     else()
-                        set(
-                            PERMISSIONS
-                            ${DEFAULT_PERMISSIONS} OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE
-                        )
+                        set(PERMISSIONS ${DEFAULT_PERMISSIONS})
                     endif()
 
                     if (DEFINED COR_INSTALL_ARCHIVE_CONFIGURATIONS)
@@ -1287,7 +1287,7 @@ function(corrosion_install)
                     endif()
 
                     install(
-                            FILES $<TARGET_PROPERTY:is_odd-static,IMPORTED_LOCATION>
+                            FILES $<TARGET_PROPERTY:${INSTALL_TARGET}-static,IMPORTED_LOCATION>
                             PERMISSIONS ${PERMISSIONS}
                             DESTINATION ${DESTINATION}
                             ${CONFIGURATIONS}

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1092,6 +1092,25 @@ function(corrosion_link_libraries target_name)
     endforeach()
 endfunction()
 
+#[=======================================================================[.md:
+ANCHOR: corrosion-install
+```cmake
+corrosion_install(TARGETS <target1> ... <targetN> [EXPORT <export-name>]
+                  [[ARCHIVE|LIBRARY|RUNTIME|PRIVATE_HEADER|PUBLIC_HEADER]
+                   [DESTINATION <dir>]
+                   [PERMISSIONS <permissions...>]
+                   [CONFIGURATIONS [Debug|Release|<other-configuration>]]
+                  ] [...])
+```
+* **TARGETS**: Target or targets to install.
+* **EXPORT**: NOT IMPLEMENTED.
+
+TODO: The `ARCHIVE`/`LIBRARY`/... nonsense works like `<artifact-kind> <artifact-option>...` from [`install(TARGETS)`].
+
+[`install(TARGETS)`]: https://cmake.org/cmake/help/latest/command/install.html#targets
+
+ANCHOR_END: corrosion-install
+#]=======================================================================]
 function(corrosion_install)
     # Default install dirs
     include(GNUInstallDirs)
@@ -1112,13 +1131,6 @@ function(corrosion_install)
     set(TARGET_ARGS ${OPTIONS} ${ONE_VALUE_ARGS} ${MULTI_VALUE_ARGS})
 
     if (INSTALL_TYPE STREQUAL "TARGETS")
-        # corrosion_install(TARGETS ... [EXPORT <export-name>]
-        #                   [[ARCHIVE|LIBRARY|RUNTIME|PRIVATE_HEADER|PUBLIC_HEADER]
-        #                    [DESTINATION <dir>]
-        #                    [PERMISSIONS permissions...]
-        #                    [CONFIGURATIONS [Debug|Release|...]]
-        #                   ] [...])
-
         # Extract targets
         set(INSTALL_TARGETS)
         list(LENGTH ARGN ARGN_LENGTH)

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1245,6 +1245,78 @@ function(corrosion_install)
                     PERMISSIONS ${PERMISSIONS}
                     ${CONFIGURATIONS}
                 )
+            elseif(TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+                if(TARGET ${INSTALL_TARGET}-static)
+                    if (DEFINED COR_INSTALL_ARCHIVE_DESTINATION)
+                        set(DESTINATION ${COR_INSTALL_ARCHIVE_DESTINATION})
+                    elseif (DEFINED COR_INSTALL_DEFAULT_DESTINATION)
+                        set(DESTINATION ${COR_INSTALL_DEFAULT_DESTINATION})
+                    else()
+                        set(DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                    endif()
+
+                    if (DEFINED COR_INSTALL_ARCHIVE_PERMISSIONS)
+                        set(PERMISSIONS ${COR_INSTALL_ARCHIVE_PERMISSIONS})
+                    elseif (DEFINED COR_INSTALL_DEFAULT_PERMISSIONS)
+                        set(PERMISSIONS ${COR_INSTALL_DEFAULT_PERMISSIONS})
+                    else()
+                        set(
+                            PERMISSIONS
+                            ${DEFAULT_PERMISSIONS} OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE
+                        )
+                    endif()
+
+                    if (DEFINED COR_INSTALL_ARCHIVE_CONFIGURATIONS)
+                        set(CONFIGURATIONS CONFIGURATIONS ${COR_INSTALL_ARCHIVE_CONFIGURATIONS})
+                    elseif (DEFINED COR_INSTALL_DEFAULT_CONFIGURATIONS)
+                        set(CONFIGURATIONS CONFIGURATIONS ${COR_INSTALL_DEFAULT_CONFIGURATIONS})
+                    else()
+                        set(CONFIGURATIONS)
+                    endif()
+
+                    install(
+                            FILES $<TARGET_PROPERTY:is_odd-static,IMPORTED_LOCATION>
+                            PERMISSIONS ${PERMISSIONS}
+                            DESTINATION ${DESTINATION}
+                            ${CONFIGURATIONS}
+                    )
+                endif()
+
+                if(TARGET ${INSTALL_TARGET}-shared)
+                    if (DEFINED COR_INSTALL_LIBRARY_DESTINATION)
+                        set(DESTINATION ${COR_INSTALL_LIBRARY_DESTINATION})
+                    elseif (DEFINED COR_INSTALL_DEFAULT_DESTINATION)
+                        set(DESTINATION ${COR_INSTALL_DEFAULT_DESTINATION})
+                    else()
+                        set(DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                    endif()
+
+                    if (DEFINED COR_INSTALL_LIBRARY_PERMISSIONS)
+                        set(PERMISSIONS ${COR_INSTALL_LIBRARY_PERMISSIONS})
+                    elseif (DEFINED COR_INSTALL_DEFAULT_PERMISSIONS)
+                        set(PERMISSIONS ${COR_INSTALL_DEFAULT_PERMISSIONS})
+                    else()
+                        set(
+                            PERMISSIONS
+                            ${DEFAULT_PERMISSIONS} OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE
+                        )
+                    endif()
+
+                    if (DEFINED COR_INSTALL_LIBRARY_CONFIGURATIONS)
+                        set(CONFIGURATIONS CONFIGURATIONS ${COR_INSTALL_LIBRARY_CONFIGURATIONS})
+                    elseif (DEFINED COR_INSTALL_DEFAULT_CONFIGURATIONS)
+                        set(CONFIGURATIONS CONFIGURATIONS ${COR_INSTALL_DEFAULT_CONFIGURATIONS})
+                    else()
+                        set(CONFIGURATIONS)
+                    endif()
+
+                    install(
+                            IMPORTED_RUNTIME_ARTIFACTS ${INSTALL_TARGET}-shared
+                            PERMISSIONS ${PERMISSIONS}
+                            DESTINATION ${DESTINATION}
+                            ${CONFIGURATIONS}
+                    )
+                endif()
             endif()
         endforeach()
 

--- a/doc/src/quick_start.md
+++ b/doc/src/quick_start.md
@@ -31,6 +31,9 @@ add_executable(your_cool_cpp_bin main.cpp)
 # A target with the same name is now available in CMake and you can use it to link the rust library into
 # your C/C++ CMake target(s).
 target_link_libraries(your_cool_cpp_bin PUBLIC rust-lib)
+
+# Rust libraries and executables can also be installed using `corrosion_install`.
+corrosion_install(TARGETS rust-lib)
 ```
 
 Please see the [Usage chapter](usage.md) for a complete discussion of possible configuration options.

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -32,12 +32,14 @@ target, see [Per Target options](#per-target-options) for details.
 [`INTERFACE`]: https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries
 [target_link_libraries]: https://cmake.org/cmake/help/latest/command/target_link_libraries.html
 
-### Install crate and headers with `corrosion_install`
+### Experimental: Install crate and headers with `corrosion_install`
 
 The default CMake [install commands] do not work correctly with the targets exported from `corrosion_import_crate()`.
 Corrosion provies `corrosion_install` to automatically install relevant files:
 
 {{#include ../../cmake/Corrosion.cmake:corrosion-install}}
+
+[install commands]: https://cmake.org/cmake/help/latest/command/install.html
 
 ### Per Target options
 

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -35,7 +35,7 @@ target, see [Per Target options](#per-target-options) for details.
 ### Experimental: Install crate and headers with `corrosion_install`
 
 The default CMake [install commands] do not work correctly with the targets exported from `corrosion_import_crate()`.
-Corrosion provies `corrosion_install` to automatically install relevant files:
+Corrosion provides `corrosion_install` to automatically install relevant files:
 
 {{#include ../../cmake/Corrosion.cmake:corrosion-install}}
 

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -32,6 +32,13 @@ target, see [Per Target options](#per-target-options) for details.
 [`INTERFACE`]: https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries
 [target_link_libraries]: https://cmake.org/cmake/help/latest/command/target_link_libraries.html
 
+### Install crate and headers with `corrosion_install`
+
+The default CMake [install commands] do not work correctly with the targets exported from `corrosion_import_crate()`.
+Corrosion provies `corrosion_install` to automatically install relevant files:
+
+{{#include ../../cmake/Corrosion.cmake:corrosion-install}}
+
 ### Per Target options
 
 Some configuration options can be specified individually for each target. You can set them via the


### PR DESCRIPTION
Works on #415 and #63.

This only installs the actual library file(s) and not extras such as headers.

Not tested on Windows for compatibility with import library files for shared libraries.

I moved the function definition out to be used as an anchor so it could be used for docs without modifying it, since I'm not entirely sure what the planned feature set of it is going to be.