### PR TITLE
Fix gnullvm and test gnullvm with msys2 in CI

### DIFF
--- a/.github/scripts/toolchains/x86_64-pc-windows-gnu-clang.cmake
+++ b/.github/scripts/toolchains/x86_64-pc-windows-gnu-clang.cmake
@@ -1,3 +1,0 @@
-set(CMAKE_C_COMPILER "clang")
-set(CMAKE_CXX_COMPILER "clang++")
-set(CMAKE_C_COMPILER_TARGET "x86_64-pc-win32-gnu")

--- a/.github/scripts/toolchains/x86_64-pc-windows-gnullvm.cmake
+++ b/.github/scripts/toolchains/x86_64-pc-windows-gnullvm.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_C_COMPILER "clang")
+set(CMAKE_CXX_COMPILER "clang++")
+set(CMAKE_C_COMPILER_TARGET "x86_64-pc-windows-gnu")
+set(CMAKE_CXX_COMPILER_TARGET "x86_64-pc-windows-gnu")

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,6 +143,56 @@ jobs:
         working-directory: build
         run: ctest --output-on-failure --build-config Debug -j 3
 
+  windows_gnullvm_msys2:
+    name: Test Windows gnullvm on msys2
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2022
+        arch:
+          - x86_64
+          # - i686
+          # - aarch64
+        generator:
+          - Ninja
+          - MSYS Makefiles
+        include:
+          - arch: x86_64
+            msystem: CLANG64
+#          - arch: i686
+#            msystem: CLANG32
+#          - arch: aarch64
+#            msystem: CLANGARM64
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        id: install_rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: ${{matrix.arch}}-pc-windows-gnullvm
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.msystem}}
+          path-type: inherit
+          install: >-
+            git
+            make
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
+      - name: Configure
+        run: cmake -S. -Bbuild -G "${{matrix.generator}}" --toolchain=.github/scripts/toolchains/${{matrix.arch}}-pc-windows-gnullvm.cmake
+      - name: Run Tests
+        working-directory: build
+        run: ctest --output-on-failure --build-config Debug -j 3
+
 # For now just test if hostbuild works when cross-compiling on windows.
 # For testing everything we would also need to install a cross-compiler first.
   windows_cross_hostbuild:
@@ -356,6 +406,7 @@ jobs:
       - visual_studio_stage2
       - windows_ninja_cl
       - windows_gnu
+      - windows_gnullvm_msys2
       - linux_stage2
       - darwin
       - test_cxxbridge

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,30 +76,6 @@
             }
         },
         {
-            "name": "x86_64-pc-windows-gnu",
-            "hidden": true,
-            "inherits": ["windows-only"],
-            "cacheVariables": {
-                "Rust_CARGO_TARGET": "x86_64-pc-windows-gnu"
-            }
-        },
-        {
-            "name": "i686-pc-windows-gnu",
-            "hidden": true,
-            "inherits": ["windows-only"],
-            "cacheVariables": {
-                "Rust_CARGO_TARGET": "i686-pc-windows-gnu"
-            }
-        },
-        {
-            "name": "aarch64-pc-windows-gnu",
-            "hidden": true,
-            "inherits": ["windows-only"],
-            "cacheVariables": {
-                "Rust_CARGO_TARGET": "aarch64-pc-windows-gnu"
-            }
-        },
-        {
             "name": "x86_64-unknown-linux-gnu",
             "hidden": true,
             "cacheVariables": {
@@ -191,7 +167,7 @@
             }
         },
         {
-            "name": "gcc",
+            "name": "host-gcc",
             "hidden": true,
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
@@ -241,36 +217,22 @@
             "inherits": ["ninja", "aarch64-pc-windows-msvc", "clang-cl", "windows-10-cross"]
         },
         {
-            "name": "ninja-x86_64-pc-windows-gnu-clang",
-            "inherits": ["ninja", "x86_64-pc-windows-gnu", "clang"]
+            "name": "ninja-x86_64-pc-windows-gnullvm",
+            "inherits": ["ninja", "windows-only", "clang"],
+            "toolchainFile": "${sourceDir}/.github/scripts/toolchains/x86_64-pc-windows-gnullvm.cmake"
         },
         {
-            "name": "make-x86_64-pc-windows-gnu-clang",
-            "inherits": ["make", "x86_64-pc-windows-gnu", "clang"]
+            "name": "make-x86_64-pc-windows-gnullvm",
+            "inherits": ["make", "windows-only", "clang"],
+            "toolchainFile": "${sourceDir}/.github/scripts/toolchains/x86_64-pc-windows-gnullvm.cmake"
         },
         {
             "name": "ninja-x86_64-pc-windows-gnu-gcc",
-            "inherits": ["ninja", "x86_64-pc-windows-gnu", "gcc", "windows-only"]
+            "inherits": ["ninja", "host-gcc", "windows-only"]
         },
         {
             "name": "make-x86_64-pc-windows-gnu-gcc",
-            "inherits": ["make", "x86_64-pc-windows-gnu", "gcc", "windows-only"]
-        },
-        {
-            "name": "ninja-i686-pc-windows-gnu-clang",
-            "inherits": ["ninja", "i686-pc-windows-gnu", "clang", "windows-10-cross"]
-        },
-        {
-            "name": "make-i686-pc-windows-gnu-clang",
-            "inherits": ["make", "i686-pc-windows-gnu", "clang", "windows-10-cross"]
-        },
-        {
-            "name": "ninja-aarch64-pc-windows-gnu-clang",
-            "inherits": ["ninja", "aarch64-pc-windows-gnu", "clang", "windows-10-cross"]
-        },
-        {
-            "name": "make-aarch64-pc-windows-gnu-clang",
-            "inherits": ["make", "aarch64-pc-windows-gnu", "clang", "windows-10-cross"]
+            "inherits": ["make", "host-gcc", "windows-only"]
         },
         {
             "name": "x86_64-unknown-linux-gnu-clang",

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -264,8 +264,12 @@ function(_corrosion_copy_byproduct_deferred target_name output_dir_prop_names ca
             string(APPEND file_names "${suffix}")
         endif()
     endif()
-
-    list(TRANSFORM file_names PREPEND "${cargo_build_dir}/" OUTPUT_VARIABLE src_file_names)
+    set(src_file_names "${file_names}")
+    if(Rust_CARGO_TARGET_ENV STREQUAL "gnullvm")
+        # Workaround for cargo not exposing implibs yet.
+        list(TRANSFORM src_file_names PREPEND "deps/" REGEX "\.dll\.a$")
+    endif()
+    list(TRANSFORM src_file_names PREPEND "${cargo_build_dir}/")
     list(TRANSFORM file_names PREPEND "${output_dir}/" OUTPUT_VARIABLE dst_file_names)
     message(DEBUG "Adding command to copy byproducts `${file_names}` to ${dst_file_names}")
     add_custom_command(TARGET _cargo-build_${target_name}


### PR DESCRIPTION
List of problems / fixes related to gnullvm:

- [x] FindRust detects when `gnullvm` should be merged (#552).
- [x] Set correct `implib` name for `gnullvm` (#552)
- [x] Handle implib location on `gnullvm`. Ideally wait for cargo fix to be merged and reach stable. But perhaps we could also have a short term workaround if it is simple.
- [x] How to invoke the linker for Rust shared libraries?
   - [x] If corrosion uses the c/c++ linker as the linker driver like we normally do, then `-lunwind` is not found. Is the default MinGW in CI suitable?
   - [x] If we don't tell Rust which linker to use, it looks for  `x86_64-w64-mingw32-clang`, which is not in PATH, and also not the same as our C/C++ target triple. Again, raises questions on the configuration of our test case.