### PR TITLE
corrosion_install: fix reconfiguring breaking EXPORTs

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1319,8 +1319,6 @@ set_target_properties(${INSTALL_TARGET}-static
 "
                         )
                     endif()
-                else()
-                    message(FATAL_ERROR "Unknown target type ${TARGET_TYPE} for install target ${INSTALL_TARGET}")
                 endif()
 
                 if(TARGET ${INSTALL_TARGET}-shared)
@@ -1384,6 +1382,8 @@ set_target_properties(${INSTALL_TARGET}-shared
                         endif()
                     endif()
                 endif()
+            else()
+                message(FATAL_ERROR "Unknown target type ${TARGET_TYPE} for install target ${INSTALL_TARGET}")
             endif()
 
             # Executables can also have export tables, so they _might_ also need header files

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1308,8 +1308,9 @@ function(corrosion_install)
 
                     if(EXPORT_NAME)
                         get_target_property(COR_FILE_NAME ${INSTALL_TARGET}-static COR_FILE_NAME)
-                        file(APPEND
-                            ${CMAKE_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}
+                        if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}-static-exists)
+                            file(APPEND
+                                ${CMAKE_CURRENT_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}
 "
 add_library(${INSTALL_TARGET}-static STATIC IMPORTED)
 set_target_properties(${INSTALL_TARGET}-static
@@ -1317,7 +1318,10 @@ set_target_properties(${INSTALL_TARGET}-static
     IMPORTED_LOCATION \"\${PACKAGE_PREFIX_DIR}/${DESTINATION}/${COR_FILE_NAME}\"
 )
 "
-                        )
+                            )
+
+                            file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}-static-exists)
+                        endif()
                     endif()
                 endif()
 
@@ -1357,9 +1361,10 @@ set_target_properties(${INSTALL_TARGET}-static
                     )
 
                     if(EXPORT_NAME)
-                        get_target_property(COR_FILE_NAME ${INSTALL_TARGET}-shared COR_FILE_NAME)
-                        file(APPEND
-                                ${CMAKE_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}
+                        if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}-shared-exists)
+                            get_target_property(COR_FILE_NAME ${INSTALL_TARGET}-shared COR_FILE_NAME)
+                            file(APPEND
+                                    ${CMAKE_CURRENT_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}
                                 "
 add_library(${INSTALL_TARGET}-shared SHARED IMPORTED)
 set_target_properties(${INSTALL_TARGET}-shared
@@ -1367,18 +1372,21 @@ set_target_properties(${INSTALL_TARGET}-shared
     IMPORTED_LOCATION \"\${PACKAGE_PREFIX_DIR}/${DESTINATION}/${COR_FILE_NAME}\"
 )
 "
-                        )
+                            )
 
-                        get_target_property(COR_IMPLIB_FILE_NAME ${INSTALL_TARGET}-shared COR_IMPLIB_FILE_NAME)
-                        if (NOT COR_IMPLIB_FILE_NAME MATCHES .*-NOTFOUND)
-                            file(APPEND
-                                ${CMAKE_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}
+                            get_target_property(COR_IMPLIB_FILE_NAME ${INSTALL_TARGET}-shared COR_IMPLIB_FILE_NAME)
+                            if (NOT COR_IMPLIB_FILE_NAME MATCHES .*-NOTFOUND)
+                                file(APPEND
+                                    ${CMAKE_CURRENT_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}
                                 "
 set_target_properties(${INSTALL_TARGET}-shared
     PROPERTIES
     IMPORTED_IMPLIB \"\${PACKAGE_PREFIX_DIR}/${DESTINATION}/${COR_IMPLIB_FILE_NAME}\"
 )"
-                            )
+                                )
+                            endif()
+
+                            file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/corrosion/${EXTRA_TARGETS_EXPORT_NAME}-shared-exists)
                         endif()
                     endif()
                 endif()


### PR DESCRIPTION
Sorry for the immediate do over, but it seems there were a few mistakes in my last PR #544.

It seems the else was accidentally put on the check for a `TARGET ${TARGET_NAME}-static` lib instead of the `TARGET_TYPE STREQUAL *`.

Additionally, I forgot to put a guard on the `file(APPEND)` statements, so every reconfigure would add yet another set of `add_library`s for both static/shared, leading to it not working.

I'm not sure what the correct solution for this is, but the current solution at the very least works.