### PR TITLE
clang,windows: fix passing link flags when using clang in GNU frontend mode on windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
           - os: windows-2022
             vs_version: vs-2022
             cmake: 3.22.6
-          - rust: 1.80.0
+          - rust: 1.81.0
           # Add variable mapping for ilammy/msvc-dev-cmd action
           - arch: x86_64
             msvc_dev_arch: amd64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
           - os: windows-2022
             vs_version: vs-2022
             cmake: 3.22.6
-          - rust: 1.54.0
+          - rust: 1.80.0
           # Add variable mapping for ilammy/msvc-dev-cmd action
           - arch: x86_64
             msvc_dev_arch: amd64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,7 @@ jobs:
         compiler:
           - cl
           - clang-cl
+          - clang
         include:
           - os: windows-2022
             vs_version: vs-2022
@@ -78,6 +79,10 @@ jobs:
           - compiler: clang-cl
             arch: i686
           - compiler: clang-cl
+            arch: aarch64
+          - compiler: clang
+            arch: i686
+          - compiler: clang
             arch: aarch64
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
           - os: windows-2022
             vs_version: vs-2022
             cmake: 3.22.6
-          - rust: 1.81.0
+          - rust: 1.54.0
           # Add variable mapping for ilammy/msvc-dev-cmd action
           - arch: x86_64
             msvc_dev_arch: amd64

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -201,6 +201,10 @@
             "inherits": ["ninja", "x86_64-pc-windows-msvc", "clang-cl"]
         },
         {
+            "name": "ninja-x86_64-pc-windows-msvc-clang",
+            "inherits": ["ninja", "x86_64-pc-windows-msvc", "clang"]
+        },
+        {
             "name": "ninja-i686-pc-windows-msvc-cl",
             "inherits": ["ninja", "i686-pc-windows-msvc", "cl", "windows-10-cross"]
         },
@@ -209,12 +213,20 @@
             "inherits": ["ninja", "i686-pc-windows-msvc", "clang-cl", "windows-10-cross"]
         },
         {
+            "name": "ninja-i686-pc-windows-msvc-clang",
+            "inherits": ["ninja", "i686-pc-windows-msvc", "clang", "windows-10-cross"]
+        },
+        {
             "name": "ninja-aarch64-pc-windows-msvc-cl",
             "inherits": ["ninja", "aarch64-pc-windows-msvc", "cl", "windows-10-cross"]
         },
         {
             "name": "ninja-aarch64-pc-windows-msvc-clang-cl",
             "inherits": ["ninja", "aarch64-pc-windows-msvc", "clang-cl", "windows-10-cross"]
+        },
+        {
+            "name": "ninja-aarch64-pc-windows-msvc-clang",
+            "inherits": ["ninja", "aarch64-pc-windows-msvc", "clang", "windows-10-cross"]
         },
         {
             "name": "ninja-x86_64-pc-windows-gnullvm",

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -184,7 +184,13 @@ function(_corrosion_determine_libs_new target_triple out_libs out_flags)
                 
                 # Flags start with / for MSVC
                 if (lib MATCHES "^/" AND ${target_triple} MATCHES "msvc$")
-                    list(APPEND flag_list "${lib}")
+                    # Windows GNU uses the compiler to invoke the linker, so -Wl, prefix is needed
+                    # https://gitlab.kitware.com/cmake/cmake/-/blob/9bed4f4d817f139f0c2e050d7420e1e247949fe4/Modules/Platform/Windows-GNU.cmake#L156
+                    if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
+                        list(APPEND flag_list "-Wl,${lib}")
+                    else()
+                        list(APPEND flag_list "${lib}")
+                    endif()
                 else()
                     # Strip leading `-l` (unix) and potential .lib suffix (windows)
                     string(REGEX REPLACE "^-l" "" "stripped_lib" "${lib}")

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -202,7 +202,7 @@ function(_corrosion_determine_libs_new target_triple out_libs out_flags)
             # We leave it up to the C/C++ executable that links in the Rust static-library
             # to determine which version of the msvc runtime library it should select.
             list(FILTER libs_list EXCLUDE REGEX "^msvcrtd?")
-            list(FILTER flag_list EXCLUDE REGEX "^/defaultlib:msvcrtd?")
+            list(FILTER flag_list EXCLUDE REGEX "^(-Wl,)?/defaultlib:msvcrtd?")
         else()
             message(DEBUG "Determining required native libraries - failed: Regex match failure.")
             message(DEBUG "`native-static-libs` not found in: `${cargo_build_error_message}`")

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -184,13 +184,7 @@ function(_corrosion_determine_libs_new target_triple out_libs out_flags)
                 
                 # Flags start with / for MSVC
                 if (lib MATCHES "^/" AND ${target_triple} MATCHES "msvc$")
-                    # Windows GNU uses the compiler to invoke the linker, so -Wl, prefix is needed
-                    # https://gitlab.kitware.com/cmake/cmake/-/blob/9bed4f4d817f139f0c2e050d7420e1e247949fe4/Modules/Platform/Windows-GNU.cmake#L156
-                    if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
-                        list(APPEND flag_list "-Wl,${lib}")
-                    else()
-                        list(APPEND flag_list "${lib}")
-                    endif()
+                    list(APPEND flag_list "${lib}")
                 else()
                     # Strip leading `-l` (unix) and potential .lib suffix (windows)
                     string(REGEX REPLACE "^-l" "" "stripped_lib" "${lib}")


### PR DESCRIPTION
Followup to #511 but adding support for GNU-style clang flags. 

The condition is really CMAKE_CXX_COMPILER_FRONTEND_VARIANT==GNU && CMAKE_CXX_LINK_EXECUTABLE starts with ${CMAKE_CXX_COMPILER}, but they are always set together, and I doubt cmake would change that. 

For msvc frontends, cmake directly invokes the linker so the passing the flags verbatim is still what we want to do. 