### PR TITLE
Propagate Apple deployment target version from CMake to `cc`

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -703,6 +703,11 @@ function(_add_cargo_build out_cargo_build_out_dir)
         list(APPEND corrosion_cc_rs_flags "SDKROOT=${CMAKE_OSX_SYSROOT}")
     endif()
 
+    # Ensure that cc-rs targets same Apple platform version as the CMake build
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_DEPLOYMENT_TARGET)
+        list(APPEND corrosion_cc_rs_flags "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    endif()
+
     corrosion_add_target_local_rustflags("${target_name}" "$<$<BOOL:${corrosion_link_args}>:-Clink-args=${corrosion_link_args}>")
 
     # todo: this should probably also be guarded by if_not_host_build_condition.

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -704,7 +704,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
     endif()
 
     # Ensure that cc-rs targets same Apple platform version as the CMake build
-    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_DEPLOYMENT_TARGET)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_DEPLOYMENT_TARGET)
         list(APPEND corrosion_cc_rs_flags "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
     endif()
 


### PR DESCRIPTION
`rustc` always targets the earliest deployment platform version possible for Rust code, but the `cc` crate defaults to the host's SDK version which is typically very recent.

When the CMake uses a toolchain that has its' own minimal supported macOS version (for example Qt), this leads to linker errors and possible crashes when deploying to older yet supported systems.