### PR TITLE
Fix corrosion_experimental_cbindgen with a non-existent target.

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1836,6 +1836,28 @@ function(corrosion_experimental_cbindgen)
         else()
             set(package_manifest_dir "${CCN_MANIFEST_DIRECTORY}")
         endif()
+
+        # create non-existent target
+        add_library("${rust_target}" INTERFACE)
+
+        # get package name
+        file(REAL_PATH "${CCN_MANIFEST_DIRECTORY}/Cargo.toml" manifest_path)
+        _cargo_metadata(json "${manifest_path}")
+
+        string(JSON packages GET "${json}" "packages")
+        string(JSON pkgs_len LENGTH "${packages}")
+        math(EXPR pkgs_len-1 "${pkgs_len} - 1")
+
+        foreach(ix RANGE ${pkgs_len-1})
+            string(JSON pkg GET "${packages}" ${ix})
+            string(JSON pkg_name GET "${pkg}" "name")
+            string(JSON pkg_manifest_path GET "${pkg}" "manifest_path")
+            if(pkg_manifest_path STREQUAL manifest_path)
+                # found the package
+                set_target_properties("${rust_target}" PROPERTIES COR_CARGO_PACKAGE_NAME "${pkg_name}")
+                break()
+            endif()
+        endforeach()
     endif()
 
     get_target_property(rust_cargo_package "${rust_target}" COR_CARGO_PACKAGE_NAME )

--- a/test/cbindgen/CMakeLists.txt
+++ b/test/cbindgen/CMakeLists.txt
@@ -9,3 +9,10 @@ set_tests_properties(cbindgen_rust2cpp_run_cpp-exe PROPERTIES PASS_REGULAR_EXPRE
 # - c++ code uses the rust lib and is used in turn by the rust bin.
 
 # todo: add a test for the DEPFILE and correct regenerating if the sources are touched.
+
+# test rust2cpp with a non-existent target
+corrosion_tests_add_test(cbindgen_non_existent_target "cpp-exe" TEST_SRC_DIR non_existent_target)
+
+set_tests_properties(cbindgen_non_existent_target_run_cpp-exe PROPERTIES PASS_REGULAR_EXPRESSION
+        "^add_point Result: Point { x: 100, y: 100 }\r?\n$"
+)

--- a/test/cbindgen/non_existent_target/CMakeLists.txt
+++ b/test/cbindgen/non_existent_target/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_project VERSION 0.1.0)
+include(../../test_header.cmake)
+
+corrosion_import_crate(MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../rust2cpp/rust/Cargo.toml")
+# cbindgen with non-existent target
+corrosion_experimental_cbindgen(TARGET rust_lib_h HEADER_NAME "rust-lib.h" MANIFEST_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../rust2cpp/rust")
+
+add_executable(cpp-exe "${CMAKE_CURRENT_SOURCE_DIR}/../rust2cpp/main.cpp")
+set_property(TARGET cpp-exe PROPERTY CXX_STANDARD 11)
+target_link_libraries(cpp-exe PUBLIC rust_lib rust_lib_h)


### PR DESCRIPTION
This assumes that corrosion_experimental_cbindgen is supposed to work with a non-existent target.
Includes test.

Fixes #562

Maybe the package name should be an argument to avoid having to parse the metadata? Design decisions are not for me.