### PR TITLE
Fix cbindgen CI test failures

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,6 +23,9 @@
   the crate-types of Rust libraries (e.g. force building as a staticlib instead of an rlib).
 - Support *-windows-gnullvm targets. 
 - experimental support in corrosion_install for installing libraries and header files
+- Add `CORROSION_TOOLS_RUST_TOOLCHAIN` cache variable which allows users to select a different
+  rust toolchain for compiling build-tools used by corrosion (currently cbindgen and cxxbridge).
+  This mainly allows using a newer toolchain for such build-tools then for the actual project.
 
 [doc-cmake-rt-output-dir]: https://cmake.org/cmake/help/latest/prop_tgt/RUNTIME_OUTPUT_DIRECTORY.html
 [#459]: https://github.com/corrosion-rs/corrosion/pull/459

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1670,6 +1670,7 @@ function(corrosion_add_cxxbridge cxx_target)
                     ${_CORROSION_CARGO} install
                     cxxbridge-cmd
                     --version "${cxx_required_version}"
+                    --locked
                     --root "${CMAKE_BINARY_DIR}/corrosion/cxxbridge_v${cxx_required_version}"
                     --quiet
                     # todo: use --target-dir to potentially reuse artifacts
@@ -1902,6 +1903,7 @@ function(corrosion_experimental_cbindgen)
                 "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
                 ${_CORROSION_CARGO} install
                     cbindgen
+                    --locked
                     --root "${local_cbindgen_install_dir}"
                     ${_CORROSION_QUIET_OUTPUT_FLAG}
                 COMMENT "Building cbindgen"

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -180,6 +180,9 @@ them **before** `find_package(Corrosion REQUIRED)`.
 - `Rust_CARGO_TARGET:STRING` - The default target triple to build for. Alter for cross-compiling.
   Default: On Visual Studio Generator, the matching triple for `CMAKE_VS_PLATFORM_NAME`. Otherwise,
   the default target triple reported by `${Rust_COMPILER} --version --verbose`.
+- `CORROSION_TOOLS_RUST_TOOLCHAIN:STRING`: Specify a different toolchain (e.g. `stable`) to use for compiling helper 
+   tools such as `cbindgen` or `cxxbridge`. This can be useful when you want to compile your project with an 
+   older rust version (e.g. for checking the MSRV), but you can build build-tools with a newer installed rust version.
 
 #### Enable Convenience Options
 
@@ -208,6 +211,10 @@ versions individually.
 - `Rust_LLVM_VERSION<_MAJOR|_MINOR|_PATCH>` - The LLVM version used by rustc.
 - `Rust_IS_NIGHTLY` - 1 if a nightly toolchain is used, otherwise 0. Useful for selecting an unstable feature for a
   crate, that is only available on nightly toolchains.
+- `Rust_RUSTUP_TOOLCHAINS`, `Rust_RUSTUP_TOOLCHAINS_RUSTC_PATH`, `Rust_RUSTUP_TOOLCHAINS_CARGO_PATH`
+  and `Rust_RUSTUP_TOOLCHAINS_VERSION`: These variables are lists, which should be iterated over with
+  CMakes `foreach(var IN ZIP_LISTS list1 list2 ...)` iterator. They provide a list of installed rustup managed toolchains and
+  the associated rustc and cargo paths as well as the corresponding rustc version.
 - Cache variables containing information based on the target triple for the selected target
   as well as the default host target:
   - `Rust_CARGO_TARGET_ARCH`, `Rust_CARGO_HOST_ARCH`: e.g. `x86_64` or `aarch64`

--- a/test/cbindgen/rust2cpp/CMakeLists.txt
+++ b/test/cbindgen/rust2cpp/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_project VERSION 0.1.0)
-include(../../test_header.cmake)
 
+set(CORROSION_TOOLS_RUST_TOOLCHAIN "stable")
+include(../../test_header.cmake)
 corrosion_import_crate(MANIFEST_PATH rust/Cargo.toml)
 corrosion_experimental_cbindgen(TARGET rust_lib HEADER_NAME "rust-lib.h")
 


### PR DESCRIPTION
- Use `--locked` to avoid potential issues with dependencies.
- Add CORROSION_TOOLS_RUST_TOOLCHAIN option: This allows users to choose a different rust toolchain
to compile build-tools use by corrosion (currently cbindgen and cxxbridge)