### PR TITLE
fix: update `FindRust` to work with rustup v1.28.0

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -334,18 +334,18 @@ if (Rust_RESOLVE_RUSTUP_TOOLCHAINS)
     set(_DISCOVERED_TOOLCHAINS_VERSION "")
 
     foreach(_TOOLCHAIN_RAW ${_TOOLCHAINS_RAW})
-        if (_TOOLCHAIN_RAW MATCHES "([a-zA-Z0-9\\._\\-]+)[ \t\r\n]?(\\(default\\) \\(override\\)|\\(default\\)|\\(override\\))?[ \t\r\n]+(.+)")
+        if (_TOOLCHAIN_RAW MATCHES "([a-zA-Z0-9\\._\\-]+)[ \t\r\n]?(\\(active\\)|\\(active, default\\)|\\(default\\) \\(override\\)|\\(default\\)|\\(override\\))?[ \t\r\n]+(.+)")
             set(_TOOLCHAIN "${CMAKE_MATCH_1}")
             set(_TOOLCHAIN_TYPE "${CMAKE_MATCH_2}")
 
             set(_TOOLCHAIN_PATH "${CMAKE_MATCH_3}")
             set(_TOOLCHAIN_${_TOOLCHAIN}_PATH "${CMAKE_MATCH_3}")
 
-            if (_TOOLCHAIN_TYPE MATCHES ".*\\(default\\).*")
+            if (_TOOLCHAIN_TYPE MATCHES ".*\\((active, )?default\\).*")
                 set(_TOOLCHAIN_DEFAULT "${_TOOLCHAIN}")
             endif()
 
-            if (_TOOLCHAIN_TYPE MATCHES ".*\\(override\\).*")
+            if (_TOOLCHAIN_TYPE MATCHES ".*\\((active|override)\\).*")
                 set(_TOOLCHAIN_OVERRIDE "${_TOOLCHAIN}")
             endif()
 


### PR DESCRIPTION
Closes #590 by applying the following mapping:

| Variable \ Rustup ver. | v1.27.1      | v1.28.0                            |
|------------------------|--------------|------------------------------------|
| `$_TOOLCHAIN_OVERRIDE` | `(override)` | `(active)`                         |
| `$_TOOLCHAIN_DEFAULT`  | `(default)`  | `(default)` or `(active, default)` |

## Rationale

Corrosion would like to find out the path for the active toolchain via `rustup toolchain list --verbose` from the toolchains marked `(override)` and/or `(default)`: if `(override)` is present, then it's active, otherwise `(default)` would be active:

https://github.com/corrosion-rs/corrosion/blob/b88ec09915a6b12d1aaec7e451ecf0e41a831030/cmake/FindRust.cmake#L423-L428

In rustup v1.28.0 beta (or https://github.com/rust-lang/rustup/pull/3225 to be more precise), we have recognized that this output format has become a common source of confusion among users in determining the active toolchain, so we now mark the active toolchain with `(active)` instead. Unfortunately, this has broken corrosion's parsing logic.

## Verification

Changes verified locally via the following interactions:

```console
> rustup --version
rustup 1.28.0 :: 1.27.1+544 (7ccf717e6 2024-12-23)
...

> rustup toolchain list --verbose # The "default" state.
stable-aarch64-apple-darwin (active, default) ...
nightly-aarch64-apple-darwin ...
nightly-2023-09-30-aarch64-apple-darwin ...

> rustup +nightly toolchain list --verbose # The "override" state.
stable-aarch64-apple-darwin (default) ...
nightly-aarch64-apple-darwin (active) ...
nightly-2023-09-30-aarch64-apple-darwin ...

> cmake -S. -Bbuild -URust_TOOLCHAIN
-- Rust Toolchain: stable-aarch64-apple-darwin
-- Rust Target: aarch64-apple-darwin
-- Found Rust: SOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc (found version "1.83.0")
-- Configuring done (0.2s)
-- Generating done (0.1s)
...

> RUSTUP_TOOLCHAIN=nightly cmake -S. -Bbuild -URust_TOOLCHAIN
-- Rust Toolchain: nightly-aarch64-apple-darwin
-- Rust Target: aarch64-apple-darwin
-- Found Rust: SOME/.rustup/toolchains/nightly-aarch64-apple-darwin/bin/rustc (found version "1.85.0")
-- Configuring done (0.2s)
-- Generating done (0.1s)
...
```

## Concerns

- [x] I'm not sure why `-URust_TOOLCHAIN` is required to make this work. Has it been somehow set to `""` by something?
- [x] Am I doing the verification right? If not, how should I properly verify this change?