### PR TITLE
Add crate features to check cxx version command

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1671,9 +1671,18 @@ function(corrosion_add_cxxbridge cxx_target)
 
     get_filename_component(manifest_dir ${manifest_path} DIRECTORY)
 
+    get_target_property(features "${_arg_CRATE}" CORROSION_FEATURES)
+    
+    # If features are empty, no need to pass them to cargo
+    if(features)
+        set(features "--features=${features}")
+    else()
+        set(features "")
+    endif()
+    
     execute_process(COMMAND ${CMAKE_COMMAND} -E env
         "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
-        ${_CORROSION_CARGO} tree -i cxx --depth=0
+        ${_CORROSION_CARGO} tree -i cxx ${features} --depth=0
         WORKING_DIRECTORY "${manifest_dir}"
         RESULT_VARIABLE cxx_version_result
         OUTPUT_VARIABLE cxx_version_output


### PR DESCRIPTION
Adds the supplied crate features to the cxx version check command so it does not fail when the cxx dependency is made optional and locked behind a feature flag.

Fixes #597 