### PR TITLE
Add cbindgen target to ALL

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -2049,7 +2049,7 @@ function(corrosion_experimental_cbindgen)
 
     set(corrosion_generated_dir "${CMAKE_CURRENT_BINARY_DIR}/corrosion_generated")
     set(generated_dir "${corrosion_generated_dir}/cbindgen/${cbindgen_bindings_target}")
-    set(header_placement_dir "${generated_dir}/include/")
+    set(header_placement_dir "${generated_dir}/include")
     set(depfile_placement_dir "${generated_dir}/depfile")
     set(generated_depfile "${depfile_placement_dir}/${output_header_name}.d")
     set(generated_header "${header_placement_dir}/${output_header_name}")

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -2113,6 +2113,7 @@ function(corrosion_experimental_cbindgen)
     # Users might want to call cbindgen multiple times, e.g. to generate separate C++ and C header files.
     string(MAKE_C_IDENTIFIER "${output_header_name}" header_identifier )
     add_custom_target("_corrosion_cbindgen_${cbindgen_bindings_target}_bindings_${header_identifier}"
+            ALL
             DEPENDS "${generated_header}"
             COMMENT "Generate ${generated_header} for ${cbindgen_bindings_target}"
     )


### PR DESCRIPTION
Hello

I ran into an issue while installing a library with a header file generated with cbindgen.

I have a minimalist project to reproduce the problem here: https://github.com/Bktero/corrosion-rs-example

It is currently using the branch of my fork I am proposing in this PR, and it works fine with it. However, if I change the `CMakeLists.txt` to use https://github.com/corrosion-rs/corrosion.git with the master branch (the latest commit being 3985d57e03acb99f1e6089fa51d072c285827b29 as I write this message), I get an error:

```shell
CMake Error at cmake_install.cmake:55 (file):
file INSTALL cannot find
"/home/pierre/bakasables/bakasable-rs/cmake-build/corrosion_generated/cbindgen/bakasable_rs/include//bakasable.h":
No such file or directory.
```

It seems that the `install` target will execute only targets that are parts of ALL. As a consequence, `make install` doesn't trigger the generation of the header. In this PR, I simply added the cbindgen target to ALL, but I don't know whether this is the most accurate solution.