### PR TITLE
cbindgen: Fix rare issue with cbindgen failing to find cargo

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -2137,6 +2137,8 @@ function(corrosion_experimental_cbindgen)
         COMMAND
         "${CMAKE_COMMAND}" -E env
             TARGET="${cbindgen_target_triple}"
+            # cbindgen invokes cargo-metadata and checks the CARGO environment variable
+            CARGO="${_CORROSION_CARGO}"
             "${cbindgen}"
                     --output "${generated_header}"
                     --crate "${rust_cargo_package}"


### PR DESCRIPTION
PATH may be different at build time, so cargo might not be in PATH, which would cause cbindgen to fail.
We point cbindgen to the correct CARGO executable explicitly instead.