### PR TITLE
Partially fix CI of stable/v0.5 branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Test Corrosion (CMake 3.15)
     uses: ./.github/workflows/test_legacy.yaml
     with:
-      os: windows-2019
+      os: windows-2022
       rust: 1.46.0
 
   test_legacy_stable:
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019 # windows-latest is currently not having a supported MSVC compiler
+          - windows-2022 # windows-latest is currently not having a supported MSVC compiler
           - ubuntu-22.04
           - macos-13
     with:
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019 # windows-latest is currently not having a supported MSVC compiler
+          - windows-2022 # windows-latest is currently not having a supported MSVC compiler
           - ubuntu-latest
           - macos-13
         arch:
@@ -96,7 +96,7 @@ jobs:
             generator: ninja
             arch: x86_64
             abi: msvc
-            os: windows-2019
+            os: windows-2022
           - rust: nightly
             cmake: 3.19.0
             generator: ninja
@@ -114,7 +114,7 @@ jobs:
             generator: ninja
             arch: x86_64
             abi: msvc
-            os: windows-2019
+            os: windows-2022
             compiler: clang
           - os: ubuntu-latest
             arch: x86_64
@@ -126,23 +126,23 @@ jobs:
         exclude:
 
           # We have a separate test Matrix for the Visual Studio Generator
-          - os: windows-2019
+          - os: windows-2022
             generator: default # Default generator is Visual Studio
 
           # ARCH
-          - os: windows-2019
+          - os: windows-2022
             arch: i686
             abi: gnu
-          - os: windows-2019
+          - os: windows-2022
             arch: aarch64
             abi: gnu
-          - os: windows-2019
+          - os: windows-2022
             arch: i686
             generator: ninja
-          - os: windows-2019
+          - os: windows-2022
             arch: aarch64
             generator: ninja
-          - os: windows-2019
+          - os: windows-2022
             arch: powerpc64le
           - os: macos-13
             arch: i686
@@ -156,7 +156,7 @@ jobs:
             abi: msvc
           - os: ubuntu-latest
             abi: darwin
-          - os: windows-2019
+          - os: windows-2022
             abi: darwin
           - os: macos-13
             abi: msvc
@@ -187,7 +187,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-2022
           - windows-2022
         arch:
           - x86_64
@@ -198,7 +198,7 @@ jobs:
           # Override rust version for x86_64
           - arch: x86_64
             rust: 1.46.0
-          - os: windows-2019
+          - os: windows-2022
             cmake: 3.20.6  # Multi-config Generators require at least CMake 3.20
           - os: windows-2022
             cmake: 3.21.5 # VS on windows-2022 requires at least CMake 3.21
@@ -235,12 +235,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-2022
           - ubuntu-latest
           - macos-13
         include:
           - abi: default
-        #  - os: windows-2019
+        #  - os: windows-2022
         #    abi: gnu
     steps:
       - uses: actions/checkout@v4
@@ -275,7 +275,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-2022
           - ubuntu-latest
           - macos-13
         include:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,13 +13,13 @@ jobs:
     name: Test Corrosion (CMake 3.15)
     uses: ./.github/workflows/test_legacy.yaml
     with :
-      os: ubuntu-20.04
+      os: ubuntu-22.04
       rust: 1.46.0
   test_legacy_mac:
     name: Test Corrosion (CMake 3.15)
     uses: ./.github/workflows/test_legacy.yaml
     with:
-      os: macos-12
+      os: macos-13
       rust: 1.54.0
   test_legacy_windows:
     name: Test Corrosion (CMake 3.15)
@@ -36,8 +36,8 @@ jobs:
       matrix:
         os:
           - windows-2019 # windows-latest is currently not having a supported MSVC compiler
-          - ubuntu-20.04
-          - macos-12
+          - ubuntu-22.04
+          - macos-13
     with:
       os: ${{ matrix.os }}
       rust: stable
@@ -46,12 +46,12 @@ jobs:
     name: Legacy CMake + nightly Rust
     uses: ./.github/workflows/test_legacy.yaml
     with:
-      os: ubuntu-20.04
+      os: ubuntu-22.04
       rust: nightly
 
   test_legacy_new_lockfile_msrv:
     name: Test MSRV of the new lockfile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -71,7 +71,7 @@ jobs:
         os:
           - windows-2019 # windows-latest is currently not having a supported MSVC compiler
           - ubuntu-latest
-          - macos-12
+          - macos-13
         arch:
           - x86_64
           - i686
@@ -108,7 +108,7 @@ jobs:
             generator: ninja
             arch: x86_64
             abi: darwin
-            os: macos-12
+            os: macos-13
           - rust: 1.54
             cmake: 3.19.0
             generator: ninja
@@ -144,11 +144,11 @@ jobs:
             generator: ninja
           - os: windows-2019
             arch: powerpc64le
-          - os: macos-12
+          - os: macos-13
             arch: i686
-          - os: macos-12
+          - os: macos-13
             arch: aarch64
-          - os: macos-12
+          - os: macos-13
             arch: powerpc64le
 
           # ABI
@@ -158,9 +158,9 @@ jobs:
             abi: darwin
           - os: windows-2019
             abi: darwin
-          - os: macos-12
+          - os: macos-13
             abi: msvc
-          - os: macos-12
+          - os: macos-13
             abi: gnu
 
     steps:
@@ -237,7 +237,7 @@ jobs:
         os:
           - windows-2019
           - ubuntu-latest
-          - macos-12
+          - macos-13
         include:
           - abi: default
         #  - os: windows-2019
@@ -277,10 +277,10 @@ jobs:
         os:
           - windows-2019
           - ubuntu-latest
-          - macos-12
+          - macos-13
         include:
           - rust: 1.46.0
-          - os: macos-12
+          - os: macos-13
             rust: 1.54.0  # On MacOS-12 linking fails before Rust 1.54
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Corrosion
     # tagged release. Users don't need to care about this, it is mainly to
     # clearly see in configure logs which version was used, without needing to
     # rely on `git`, since Corrosion may be installed or otherwise packaged.
-    VERSION 0.5.0
+    VERSION 0.5.1
     LANGUAGES NONE
     HOMEPAGE_URL "https://corrosion-rs.github.io/corrosion/"
 )

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1782,6 +1782,13 @@ function(corrosion_experimental_cbindgen)
                           DEPENDS "${generated_header}"
                           COMMENT "Generate ${generated_header} for ${rust_target}"
         )
+        if(NOT installed_cbindgen)
+            add_custom_command(
+                    OUTPUT "${generated_header}"
+                    APPEND
+                    DEPENDS _corrosion_cbindgen
+            )
+        endif()
     else()
         add_custom_target("_corrosion_cbindgen_${rust_target}_bindings_${header_identifier}"
                           "${CMAKE_COMMAND}" -E env
@@ -1795,14 +1802,9 @@ function(corrosion_experimental_cbindgen)
                           COMMAND_EXPAND_LISTS
                           WORKING_DIRECTORY "${package_manifest_dir}"
         )
-    endif()
-
-    if(NOT installed_cbindgen)
-        add_custom_command(
-            OUTPUT "${generated_header}"
-            APPEND
-            DEPENDS _corrosion_cbindgen
-        )
+        if(NOT installed_cbindgen)
+            add_dependencies("_corrosion_cbindgen_${rust_target}_bindings_${header_identifier}" _corrosion_cbindgen)
+        endif()
     endif()
 
     if(NOT TARGET "_corrosion_cbindgen_${rust_target}_bindings")


### PR DESCRIPTION
It seems that previously `cbindgen` was preinstalled on some runner images. Now that doesn't seem to be the case anymore, which is causing CI failures.

The remaining CI issue is that the latest cbindgen version requires a newer rust version to install than we test in CI.
I believe this is already fixed in main, but we ignore this issue on the stable branch, since it is not critical.