### PR TITLE
cbindgen: Fix bindings if rustc is not in path

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -2139,6 +2139,7 @@ function(corrosion_experimental_cbindgen)
             TARGET="${cbindgen_target_triple}"
             # cbindgen invokes cargo-metadata and checks the CARGO environment variable
             CARGO="${_CORROSION_CARGO}"
+            RUSTC="${_CORROSION_RUSTC}"
             "${cbindgen}"
                     --output "${generated_header}"
                     --crate "${rust_cargo_package}"


### PR DESCRIPTION
Followup to 715c235daef4b8ee67278f12256334ad3dd4c4ae.