### PR TITLE
CI: Remove testing on windows-2019

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         vs_version:
-          - "2019"
           - "2022"
         arch:
           - x86_64


### PR DESCRIPTION
The windows-2019 images were removed.
The windows-2025 image still ships with VS 2022, so there probably is not too much point explicitly testing on windows-2025 too.