### PR TITLE
CI: update macos images

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -320,7 +320,7 @@ jobs:
         os:
           - windows-2022
           - ubuntu-latest
-          - macos-13
+          - macos-15
         include:
           # Should be in sync with the `cxx` version the Carg.lock of the cxxbridge tests,
           # otherwise the caching will not work and the cmd will be built from source.
@@ -396,7 +396,7 @@ jobs:
         os:
           - windows-2022
           - ubuntu-latest
-          - macos-13
+          - macos-15
         include:
           - rust: 1.54.0
 


### PR DESCRIPTION
macos-13 is being removed in the beginning of december, so we need to migrate to a newer image.
This also implies switching to aarch64 mac, so lets hope no assumptions break in the tests.