### PR TITLE
Fix of the iOS fix

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -794,19 +794,14 @@ function(_add_cargo_build out_cargo_build_out_dir)
     # assumes `cc` is a valid linker driver for the host platform (but in this case `cc` targets iOS).
     # To work around this we explicitly set the linker for the host platform, and use a dummy CMake project
     # to determine a suitable C compiler.
-    unset(cargo_host_target_linker)
     if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_NAME STREQUAL "iOS")
+        unset(cargo_host_target_linker)
+
         message(CHECK_START "Determining linker for host architecture (${Rust_CARGO_HOST_TARGET_CACHED})")
-        string(TOUPPER Rust_CARGO_HOST_TARGET_CACHED host_target_upper)
-        string(REPLACE "-" "_" host_target_upper host_target_upper_underscore)
-        unset(corrosion_host_c_compiler)
-        _corrosion_determine_host_compiler(corrosion_host_c_compiler cor_error_info)
-        if(DEFINED corrosion_host_c_compiler)
-            message(CHECK_PASS "${corrosion_host_c_compiler}")
-            set(cargo_host_target_linker "CARGO_TARGET_${host_target_upper_underscore}_LINKER=${corrosion_host_c_compiler}")
-        else()
-            message(CHECK_FAIL "Failed - ${cor_error_info}")
-        endif()
+        string(TOUPPER ${Rust_CARGO_HOST_TARGET_CACHED} host_target_upper)
+        string(REPLACE "-" "_" host_target_upper_underscore ${host_target_upper})
+
+        set(cargo_host_target_linker "CARGO_TARGET_${host_target_upper_underscore}_LINKER=/usr/bin/cc")
     endif()
 
     # Since we instruct cc-rs to use the compiler found by CMake, it is likely one that requires also
@@ -898,7 +893,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
         # to determine the correct target directory, depending on if the hostbuild target property is
         # set or not.
         # BYPRODUCTS  "${cargo_build_dir}/${build_byproducts}"
-        
+
         # Set WORKING_DIRECTORY to the directory containing the manifest, so that configuration files
         # such as `.cargo/config.toml` or `toolchain.toml` are applied as expected. Cargo searches for
         # configuration files by walking upward from the current directory.
@@ -2297,48 +2292,6 @@ function(corrosion_parse_package_version package_manifest_path out_package_versi
             "NOTFOUND"
             PARENT_SCOPE
         )
-    endif()
-endfunction()
-
-function(_corrosion_determine_host_compiler host_c_compiler_out error_out)
-    # Create minimal CMakeLists.txt to be generated for the host.
-    set(package_dir "${CMAKE_BINARY_DIR}/corrosion/host_compiler")
-    file(REMOVE_RECURSE "${package_dir}")
-    file(MAKE_DIRECTORY "${package_dir}")
-    set(lists "cmake_minimum_required(VERSION 3.10)\n")
-    string(APPEND lists "project(CorrosionDetermineHostCompiler LANGUAGES C)\n")
-    # We add a `:` after the compiler so we can easily match the end, since `:` is
-    # invalid in filenames.
-    string(APPEND lists "message(STATUS \"HOST_C_COMPILER=\${CMAKE_C_COMPILER}:\")\n")
-    file(WRITE "${package_dir}/CMakeLists.txt" "${lists}")
-
-    # Generate the CMake project.
-    execute_process(
-            COMMAND ${CMAKE_COMMAND}
-            -DCMAKE_CROSSCOMPILING=OFF
-            "${package_dir}"
-            WORKING_DIRECTORY "${package_dir}"
-            OUTPUT_VARIABLE host_detection_output
-            ERROR_VARIABLE host_detection_error
-            RESULT_VARIABLE host_detection_result
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_STRIP_TRAILING_WHITESPACE
-    )
-
-    # Check if configuring the dummy CMake project failed.
-    if(NOT host_detection_result EQUAL 0)
-        message(WARNING "Failed to detect host compiler. Result: ${host_detection_result}\n"
-                "Output: ${host_detection_output}\n"
-                "Error: ${host_detection_result}")
-        return()
-    endif()
-
-    # Extract C compiler from the output.
-    string(REGEX MATCH "HOST_C_COMPILER=([^:\r\n]*):" host_c_compiler_match "${host_detection_output}")
-    if(host_c_compiler_match)
-        set("${host_c_compiler_out}" "${CMAKE_MATCH_1}" PARENT_SCOPE)
-    else()
-        set("${error_out}" "Regex match failure: ${host_detection_output}")
     endif()
 endfunction()
 


### PR DESCRIPTION
Hello everyone,

I've been following PR https://github.com/corrosion-rs/corrosion/pull/636 and left a comment there earlier. The initial commit in that branch fixed the build in my environment, but the subsequent changes unfortunately broke it again.

In this PR, I’ve corrected a few issues in the logic that converts a host target string to the uppercase-underscore format. These fixes are necessary but not the core issue.

From what I can see, the real problem is in _corrosion_determine_host_compiler. Calling cc using its full path behaves differently from calling /usr/bin/cc. You can verify this by compiling a file with an empty main():

<details>
  <summary>generic cc output</summary>

```txt
/usr/bin/cc -v t.c -o t
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin25.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
  -cc1
  -triple
  arm64-apple-macosx16.0.0
  -Wundef-prefix=TARGET_OS_
  -Wdeprecated-objc-isa-usage
  -Werror=deprecated-objc-isa-usage
  -Werror=implicit-function-declaration
  -emit-obj
  -dumpdir t-
  -disable-free
  -clear-ast-before-backend
  -disable-llvm-verifier
  -discard-value-names
  -main-file-name t.c
  -mrelocation-model pic
  -pic-level 2
  -mframe-pointer=non-leaf
  -fno-strict-return
  -ffp-contract=on
  -fno-rounding-math
  -funwind-tables=1
  -fobjc-msgsend-selector-stubs
  -target-sdk-version=26.1
  -fvisibility-inlines-hidden-static-local-var
  -fdefine-target-os-macros
  -fno-assume-unique-vtables
  -fno-modulemap-allow-subdirectory-search
  -target-cpu apple-m1
  -target-feature +zcm
  -target-feature +zcz
  -target-feature +v8.5a
  -target-feature +aes
  -target-feature +altnzcv
  -target-feature +ccdp
  -target-feature +complxnum
  -target-feature +crc
  -target-feature +dotprod
  -target-feature +fp-armv8
  -target-feature +fp16fml
  -target-feature +fptoint
  -target-feature +fullfp16
  -target-feature +jsconv
  -target-feature +lse
  -target-feature +neon
  -target-feature +pauth
  -target-feature +perfmon
  -target-feature +predres
  -target-feature +ras
  -target-feature +rcpc
  -target-feature +rdm
  -target-feature +sb
  -target-feature +sha2
  -target-feature +sha3
  -target-feature +specrestrict
  -target-feature +ssbs
  -target-abi darwinpcs
  -debugger-tuning=lldb
  -fdebug-compilation-dir=/Users/maxim/Projects
  -target-linker-version 1167.5
  -v
  -fcoverage-compilation-dir=/Users/maxim/Projects
  -resource-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17
  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
  -I/usr/local/include
  -internal-isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/local/include
  -internal-isystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include
  -internal-externc-isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
  -internal-externc-isystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include
  -Wno-reorder-init-list
  -Wno-implicit-int-float-conversion
  -Wno-c99-designator
  -Wno-final-dtor-non-final-class
  -Wno-extra-semi-stmt -Wno-misleading-indentation
  -Wno-quoted-include-in-framework-header
  -Wno-implicit-fallthrough
  -Wno-enum-enum-conversion
  -Wno-enum-float-conversion
  -Wno-elaborated-enum-base
  -Wno-reserved-identifier
  -Wno-gnu-folding-constant
  -ferror-limit 19
  -stack-protector 1
  -fstack-check
  -mdarwin-stkchk-strong-link
  -fblocks
  -fencode-extended-block-signature
  -fregister-global-dtors-with-atexit
  -fgnuc-version=4.2.1
  -fskip-odr-check-in-gmf
  -fmax-type-align=16
  -fcommon
  -fcolor-diagnostics
  -clang-vendor-feature=+disableNonDependentMemberExprInCurrentInstantiation
  -fno-odr-hash-protocols
  -clang-vendor-feature=+enableAggressiveVLAFolding
  -clang-vendor-feature=+revert09abecef7bbf
  -clang-vendor-feature=+thisNoAlignAttr
  -clang-vendor-feature=+thisNoNullAttr
  -clang-vendor-feature=+disableAtImportPrivateFrameworkInImplementationError
  -D__GCC_HAVE_DWARF2_CFI_ASM=1
  -o /var/folders/4q/sc28llv95_5709cnrrk0jdkc0000gn/T/t-94b6be.o
  -x c t.c
clang -cc1 version 17.0.0 (clang-1700.0.13.5) default target arm64-apple-darwin25.1.0
ignoring nonexistent directory "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/local/include"
ignoring nonexistent directory "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/Library/Frameworks"
#include "..." search starts here:
#include <...> search starts here:
 /usr/local/include
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include
 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks (framework directory)
 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/SubFrameworks (framework directory)
End of search list.
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld"
  -demangle
  -lto_library /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libLTO.dylib
  -no_deduplicate
  -dynamic
  -arch arm64
  -platform_version macos 16.0.0 26.1
  -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
  -mllvm
  -enable-linkonceodr-outlining
  -o t
  /var/folders/4q/sc28llv95_5709cnrrk0jdkc0000gn/T/t-94b6be.o
  -L/usr/local/lib
  -lSystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/lib/darwin/libclang_rt.osx.a
```

</details>

<details>
  <summary>full path output</summary>

full path:
```txt
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -v t.c -o t
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin25.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
  -cc1
  -triple arm64-apple-macosx16.0.0
  -Wundef-prefix=TARGET_OS_
  -Wdeprecated-objc-isa-usage
  -Werror=deprecated-objc-isa-usage
  -Werror=implicit-function-declaration
  -emit-obj
  -dumpdir t-
  -disable-free
  -clear-ast-before-backend
  -disable-llvm-verifier
  -discard-value-names
  -main-file-name t.c
  -mrelocation-model pic
  -pic-level 2
  -mframe-pointer=non-leaf
  -fno-strict-return
  -ffp-contract=on
  -fno-rounding-math
  -funwind-tables=1
  -fobjc-msgsend-selector-stubs
  -fcompatibility-qualified-id-block-type-checking
  -fvisibility-inlines-hidden-static-local-var
  -fbuiltin-headers-in-system-modules
  -fdefine-target-os-macros
  -fno-assume-unique-vtables
  -target-cpu apple-m1
  -target-feature +zcm
  -target-feature +zcz
  -target-feature +v8.5a
  -target-feature +aes
  -target-feature +altnzcv
  -target-feature +ccdp
  -target-feature +complxnum
  -target-feature +crc
  -target-feature +dotprod
  -target-feature +fp-armv8
  -target-feature +fp16fml
  -target-feature +fptoint
  -target-feature +fullfp16
  -target-feature +jsconv
  -target-feature +lse
  -target-feature +neon
  -target-feature +pauth
  -target-feature +perfmon
  -target-feature +predres
  -target-feature +ras
  -target-feature +rcpc
  -target-feature +rdm
  -target-feature +sb
  -target-feature +sha2
  -target-feature +sha3
  -target-feature +specrestrict
  -target-feature +ssbs
  -target-abi darwinpcs
  -debugger-tuning=lldb
  -fdebug-compilation-dir=/Users/maxim/Projects
  -target-linker-version 1167.5
  -v -fcoverage-compilation-dir=/Users/maxim/Projects
  -resource-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17
  -internal-isystem /usr/local/include
  -internal-isystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include
  -internal-externc-isystem /usr/include
  -internal-externc-isystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include
  -Wno-reorder-init-list
  -Wno-implicit-int-float-conversion
  -Wno-c99-designator
  -Wno-final-dtor-non-final-class
  -Wno-extra-semi-stmt
  -Wno-misleading-indentation
  -Wno-quoted-include-in-framework-header
  -Wno-implicit-fallthrough
  -Wno-enum-enum-conversion
  -Wno-enum-float-conversion
  -Wno-elaborated-enum-base
  -Wno-reserved-identifier
  -Wno-gnu-folding-constant
  -ferror-limit 19
  -stack-protector 1
  -fstack-check
  -mdarwin-stkchk-strong-link
  -fblocks
  -fencode-extended-block-signature
  -fregister-global-dtors-with-atexit
  -fgnuc-version=4.2.1
  -fskip-odr-check-in-gmf
  -fmax-type-align=16
  -fcommon
  -fcolor-diagnostics
  -clang-vendor-feature=+disableNonDependentMemberExprInCurrentInstantiation
  -fno-odr-hash-protocols
  -clang-vendor-feature=+enableAggressiveVLAFolding
  -clang-vendor-feature=+revert09abecef7bbf
  -clang-vendor-feature=+thisNoAlignAttr
  -clang-vendor-feature=+thisNoNullAttr
  -clang-vendor-feature=+disableAtImportPrivateFrameworkInImplementationError
  -D__GCC_HAVE_DWARF2_CFI_ASM=1
  -o /var/folders/4q/sc28llv95_5709cnrrk0jdkc0000gn/T/t-cb20b1.o
  -x c t.c
clang -cc1 version 17.0.0 (clang-1700.0.13.5) default target arm64-apple-darwin25.1.0
ignoring nonexistent directory "/usr/include"
#include "..." search starts here:
#include <...> search starts here:
 /usr/local/include
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include
 /System/Library/Frameworks (framework directory)
 /System/Library/SubFrameworks (framework directory)
 /Library/Frameworks (framework directory)
End of search list.
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld"
  -demangle
  -lto_library /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libLTO.dylib
  -no_deduplicate
  -dynamic
  -arch arm64
  -platform_version macos 16.0.0 16.0.0
  -mllvm
  -enable-linkonceodr-outlining
  -o t
  /var/folders/4q/sc28llv95_5709cnrrk0jdkc0000gn/T/t-cb20b1.o
  -lSystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/lib/darwin/libclang_rt.osx.a
ld: library 'System' not found
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```

</details>

In the latter case, some arguments—such as `-isysroot` are missing, and even an empty file fails to compile. This mirrors the error I see during iOS build: `ld: library 'System' not found`

With the changes in this PR applied, the project builds correctly in my environment.

I’m not suggesting merging this PR as-is, my intention is primarily to start a discussion. The solution likely needs refinement, at least with comments.
