### PR TITLE
Honor CARGO_HOME env var when searching for rust binaries

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -907,7 +907,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
         # to determine the correct target directory, depending on if the hostbuild target property is
         # set or not.
         # BYPRODUCTS  "${cargo_build_dir}/${build_byproducts}"
-        
+
         # Set WORKING_DIRECTORY to the directory containing the manifest, so that configuration files
         # such as `.cargo/config.toml` or `toolchain.toml` are applied as expected. Cargo searches for
         # configuration files by walking upward from the current directory.
@@ -2150,7 +2150,8 @@ function(corrosion_experimental_cbindgen)
 
     set(output_header_name "${CCN_HEADER_NAME}")
 
-    find_program(installed_cbindgen cbindgen)
+    _corrosion_find_rust_paths(_cbindgen_rust_paths)
+    find_program(installed_cbindgen cbindgen PATHS ${_cbindgen_rust_paths})
 
     # Install the newest cbindgen version into our build tree.
     if(installed_cbindgen)

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -1822,7 +1822,8 @@ function(corrosion_add_cxxbridge cxx_target)
     endif()
 
     # First check if a suitable version of cxxbridge is installed
-    find_program(INSTALLED_CXXBRIDGE cxxbridge PATHS "$ENV{HOME}/.cargo/bin/")
+    _corrosion_find_rust_paths(_cxxbridge_rust_paths)
+    find_program(INSTALLED_CXXBRIDGE cxxbridge PATHS ${_cxxbridge_rust_paths})
     mark_as_advanced(INSTALLED_CXXBRIDGE)
     if(INSTALLED_CXXBRIDGE)
         execute_process(COMMAND ${INSTALLED_CXXBRIDGE} --version OUTPUT_VARIABLE cxxbridge_version_output)

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -224,7 +224,7 @@ set(Rust_RESOLVE_RUSTUP_TOOLCHAINS ON CACHE BOOL ${_RESOLVE_RUSTUP_TOOLCHAINS_DE
 # This block checks to see if we're prioritizing a rustup-managed toolchain.
 if (DEFINED Rust_TOOLCHAIN)
     # If the user specifies `Rust_TOOLCHAIN`, then look for `rustup` first, rather than `rustc`.
-    find_program(Rust_RUSTUP rustup PATHS "$ENV{HOME}/.cargo/bin")
+    find_program(Rust_RUSTUP rustup PATHS "$ENV{CARGO_HOME}/bin" "$ENV{HOME}/.cargo/bin")
     if(NOT Rust_RUSTUP)
         if(NOT "${Rust_FIND_QUIETLY}")
             message(
@@ -253,10 +253,10 @@ else()
             return()
         endif()
     else()
-        find_program(_Rust_COMPILER_TEST rustc PATHS "$ENV{HOME}/.cargo/bin")
+        find_program(_Rust_COMPILER_TEST rustc PATHS "$ENV{CARGO_HOME}/bin" "$ENV{HOME}/.cargo/bin")
         if(NOT EXISTS "${_Rust_COMPILER_TEST}")
             cmake_path(CONVERT "$ENV{HOME}/.cargo/bin" TO_CMAKE_PATH_LIST _cargo_bin_dir)
-            set(_ERROR_MESSAGE "`rustc` not found in PATH or `${_cargo_bin_dir}`.\n"
+            set(_ERROR_MESSAGE "`rustc` not found in PATH, `$CARGO_HOME/bin` or `${_cargo_bin_dir}`.\n"
                     "Hint: Check if `rustc` is in PATH or manually specify the location "
                     "by setting `Rust_COMPILER` to the path to `rustc`.")
             _findrust_failed(${_ERROR_MESSAGE})

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -221,10 +221,23 @@ endif()
 set(_RESOLVE_RUSTUP_TOOLCHAINS_DESC "Indicates whether to descend into the toolchain pointed to by rustup")
 set(Rust_RESOLVE_RUSTUP_TOOLCHAINS ON CACHE BOOL ${_RESOLVE_RUSTUP_TOOLCHAINS_DESC})
 
+function(_corrosion_find_rust_paths out_paths)
+    set(paths)
+    if(DEFINED ENV{CARGO_HOME} AND NOT "$ENV{CARGO_HOME}" STREQUAL "")
+        list(APPEND paths "$ENV{CARGO_HOME}/bin")
+    endif()
+    if(DEFINED ENV{HOME} AND NOT "$ENV{HOME}" STREQUAL "")
+        list(APPEND paths "$ENV{HOME}/.cargo/bin")
+    endif()
+    set("${out_paths}" "${paths}" PARENT_SCOPE)
+endfunction()
+
+_corrosion_find_rust_paths(_corrosion_rust_paths)
+
 # This block checks to see if we're prioritizing a rustup-managed toolchain.
 if (DEFINED Rust_TOOLCHAIN)
     # If the user specifies `Rust_TOOLCHAIN`, then look for `rustup` first, rather than `rustc`.
-    find_program(Rust_RUSTUP rustup PATHS "$ENV{CARGO_HOME}/bin" "$ENV{HOME}/.cargo/bin")
+    find_program(Rust_RUSTUP rustup PATHS ${_corrosion_rust_paths})
     if(NOT Rust_RUSTUP)
         if(NOT "${Rust_FIND_QUIETLY}")
             message(
@@ -253,7 +266,7 @@ else()
             return()
         endif()
     else()
-        find_program(_Rust_COMPILER_TEST rustc PATHS "$ENV{CARGO_HOME}/bin" "$ENV{HOME}/.cargo/bin")
+        find_program(_Rust_COMPILER_TEST rustc PATHS ${_corrosion_rust_paths})
         if(NOT EXISTS "${_Rust_COMPILER_TEST}")
             cmake_path(CONVERT "$ENV{HOME}/.cargo/bin" TO_CMAKE_PATH_LIST _cargo_bin_dir)
             set(_ERROR_MESSAGE "`rustc` not found in PATH, `$CARGO_HOME/bin` or `${_cargo_bin_dir}`.\n"


### PR DESCRIPTION
Don't just check $HOME/.cargo/bin, first check $CARGO_HOME/bin when looking for binaries. This way we can also find cargo in custom install locations. It should also allow us to simplify packaging of corrosion in vcpkg, by adding CARGO_HOME to VCPKG_KEEP_ENV_VARS.